### PR TITLE
feat: add HTTP proxy support via config or env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ server-private/
 .bgm-cli/
 bangumi-development
 bgm-dev.env
-oauth-backend/node_modules/
+node_modules/
 oauth-backend/.vercel/
 .DS_Store
 **/.DS_Store

--- a/docs/features.zh-CN.md
+++ b/docs/features.zh-CN.md
@@ -19,6 +19,7 @@
 - 读取热门条目和热门条目讨论
 - 读取社区维护的 Bangumi 可用性状态源
 - 在普通终端输出和 `--json` 机器输出之间切换
+- 通过 HTTP/HTTPS 代理访问 Bangumi API
 
 以下能力当前属于实验性范围，请单独阅读 [`experimental.zh-CN.md`](./experimental.zh-CN.md)：
 
@@ -53,6 +54,18 @@
 | `bgm config show` | 显示当前生效配置 |
 | `bgm config set <key> <value>` | 写入一个配置项 |
 | `bgm config unset <key>` | 删除一个配置项 |
+
+### 代理
+
+为所有 HTTP 请求（包含 `api.bgm.tv` 和 `next.bgm.tv/p1`）设置代理。优先级：`config.proxy` > `BGM_PROXY` > `HTTPS_PROXY` > `https_proxy` > `HTTP_PROXY` > `http_proxy`。
+
+| 命令 | 说明 |
+| --- | --- |
+| `bgm proxy show` | 查看当前生效代理及其来源 |
+| `bgm proxy set <url>` | 持久化设置代理 URL（写入 user config） |
+| `bgm proxy unset` | 清除代理配置 |
+
+也可以通过 `bgm config set proxy <url>` 设置，效果等价。
 
 ### 状态
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,29 @@
 {
   "name": "bgm-cli",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bgm-cli",
-      "version": "0.1.8",
+      "version": "0.1.9",
+      "dependencies": {
+        "undici": "^8.3.0"
+      },
       "bin": {
         "bgm": "src/cli.js"
       },
       "engines": {
         "node": ">=20"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
+      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -13,5 +13,8 @@
   },
   "engines": {
     "node": ">=20"
+  },
+  "dependencies": {
+    "undici": "^8.3.0"
   }
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -10,6 +10,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import readline from "node:readline/promises";
 import { fileURLToPath } from "node:url";
 import { BangumiClient, BangumiOAuthClient, OAuthBackendClient } from "./core/client.js";
+import { getInstalledProxy, installProxyFromConfig, resolveProxyUrl } from "./core/proxy.js";
 import { DEFAULT_TURNSTILE_TIMEOUT_MS, startTurnstileFlow } from "./core/turnstile.js";
 import {
   ConfigError,
@@ -135,6 +136,12 @@ async function main(argv) {
     rawArgs: parsed.args,
   };
 
+  try {
+    installProxyFromConfig(getConfig());
+  } catch (error) {
+    process.stderr.write(`Warning: ${error?.message ?? error}\n`);
+  }
+
   if (parsed.version) {
     printResult(buildVersionStatusPayload(REPO_ROOT), context);
     return;
@@ -163,6 +170,9 @@ async function main(argv) {
       return;
     case "config":
       await runConfigCommand(command, rest, context);
+      return;
+    case "proxy":
+      await runProxyCommand(command, rest, context);
       return;
     case "auth":
       await runAuthCommand(command, rest, context);
@@ -525,11 +535,18 @@ async function runHostedOAuthInit(config, userAgent, context, rl) {
 async function runConfigCommand(command, args, context) {
   switch (command) {
     case "show": {
+      const config = getConfig();
+      const proxy = resolveProxyUrl(config);
       printResult(
         {
           configFile: getConfigFilePath(),
           configSourceFile: getConfigSourceFilePath(),
-          config: getConfig(),
+          config,
+          effectiveProxy: {
+            url: proxy.url || null,
+            source: proxy.source,
+            active: Boolean(getInstalledProxy()),
+          },
         },
         context,
       );
@@ -576,6 +593,56 @@ async function runConfigCommand(command, args, context) {
   }
 }
 
+async function runProxyCommand(command, args, context) {
+  switch (command) {
+    case undefined:
+    case "show": {
+      const proxy = resolveProxyUrl(getConfig());
+      printResult(
+        {
+          proxy: {
+            url: proxy.url || null,
+            source: proxy.source,
+            active: Boolean(getInstalledProxy()),
+          },
+        },
+        context,
+      );
+      return;
+    }
+    case "set": {
+      const [url] = args;
+      if (!url) {
+        throw new CommandError("Usage: bgm proxy set <url>");
+      }
+
+      const normalizedValue = normalizeConfigValue("proxy", url);
+      await setConfigValues({ proxy: normalizedValue });
+      printResult(
+        {
+          updated: "proxy",
+          configFile: getConfigFilePath(),
+          value: normalizedValue,
+        },
+        context,
+      );
+      return;
+    }
+    case "unset": {
+      await clearConfigValue("proxy");
+      printResult(
+        {
+          removed: "proxy",
+          configFile: getConfigFilePath(),
+        },
+        context,
+      );
+      return;
+    }
+    default:
+      throw new CommandError("Usage: bgm proxy <show|set|unset> ...");
+  }
+}
 
 async function runSetupCommand(command, args, context) {
   switch (command) {

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -44,6 +44,7 @@ const ENV_TO_KEY = {
   BGM_APP_VERSION: "appVersion",
   BGM_USER_AGENT: "userAgent",
   BGM_TIMEZONE: "timezone",
+  BGM_PROXY: "proxy",
 };
 
 export function getConfigFilePath() {
@@ -85,7 +86,35 @@ export function normalizeConfigValue(key, value) {
     return normalizeTimezone(value);
   }
 
+  if (key === "proxy") {
+    return normalizeProxy(value);
+  }
+
   return value;
+}
+
+export function normalizeProxy(value) {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  const raw = String(value).trim();
+  if (raw === "") {
+    return "";
+  }
+
+  try {
+    const parsed = new URL(raw);
+    if (!["http:", "https:"].includes(parsed.protocol)) {
+      throw new ConfigError(`Unsupported proxy protocol: ${parsed.protocol}`);
+    }
+    return parsed.toString().replace(/\/+$/, "");
+  } catch (error) {
+    if (error instanceof ConfigError) {
+      throw error;
+    }
+    throw new ConfigError(`Invalid proxy URL: ${value}`);
+  }
 }
 
 export function normalizeTimezone(value) {
@@ -343,6 +372,10 @@ function normalizeEnvValue(key, value) {
 
   if (key === "timezone") {
     return normalizeTimezone(value);
+  }
+
+  if (key === "proxy") {
+    return normalizeProxy(value);
   }
 
   return value;

--- a/src/core/output.js
+++ b/src/core/output.js
@@ -369,6 +369,10 @@ export function formatDisplayResult(value, context = {}) {
     return formatConfigMutation(value);
   }
 
+  if (isProxyShowPayload(value)) {
+    return formatProxyShow(value);
+  }
+
   if (isVersionStatusPayload(value)) {
     return formatVersionStatus(value);
   }
@@ -614,13 +618,22 @@ function formatConfigShow(payload) {
 
   if (entries.length === 0) {
     lines.push("  Values: empty");
-    return lines.join("\n");
+  } else {
+    lines.push("  Values:");
+    for (const [key, rawValue] of entries) {
+      lines.push(`    ${key}: ${formatConfigValue(key, rawValue)}`);
+    }
   }
 
-  lines.push("  Values:");
-  for (const [key, rawValue] of entries) {
-    lines.push(`    ${key}: ${formatConfigValue(key, rawValue)}`);
+  if (payload.effectiveProxy) {
+    const { url, source, active } = payload.effectiveProxy;
+    if (url) {
+      lines.push(`  Proxy: ${url} (source: ${source}, active: ${active ? "yes" : "no"})`);
+    } else {
+      lines.push("  Proxy: not set");
+    }
   }
+
   return lines.join("\n");
 }
 
@@ -3285,6 +3298,23 @@ function isConfigShowPayload(value) {
 
 function isConfigMutationPayload(value) {
   return isObject(value) && "configFile" in value && ("updated" in value || "removed" in value);
+}
+
+function isProxyShowPayload(value) {
+  return isObject(value) && isObject(value.proxy) && "source" in value.proxy && "active" in value.proxy;
+}
+
+function formatProxyShow(payload) {
+  const { url, source, active } = payload.proxy;
+  if (!url) {
+    return "Proxy: not set";
+  }
+  return [
+    "Proxy",
+    `  URL: ${url}`,
+    `  Source: ${source}`,
+    `  Active: ${active ? "yes" : "no"}`,
+  ].join("\n");
 }
 
 function isVersionStatusPayload(value) {

--- a/src/core/proxy.js
+++ b/src/core/proxy.js
@@ -1,0 +1,46 @@
+import { ProxyAgent, setGlobalDispatcher } from "undici";
+
+let installedProxy = null;
+
+export function resolveProxyUrl(config) {
+  const fromConfig = typeof config?.proxy === "string" ? config.proxy.trim() : "";
+  if (fromConfig) {
+    return { url: fromConfig, source: "config" };
+  }
+
+  const envCandidates = [
+    ["HTTPS_PROXY", process.env.HTTPS_PROXY],
+    ["https_proxy", process.env.https_proxy],
+    ["HTTP_PROXY", process.env.HTTP_PROXY],
+    ["http_proxy", process.env.http_proxy],
+  ];
+
+  for (const [name, value] of envCandidates) {
+    if (typeof value === "string" && value.trim() !== "") {
+      return { url: value.trim(), source: `env:${name}` };
+    }
+  }
+
+  return { url: "", source: "none" };
+}
+
+export function installProxyFromConfig(config) {
+  const { url, source } = resolveProxyUrl(config);
+  if (!url) {
+    installedProxy = null;
+    return null;
+  }
+
+  try {
+    setGlobalDispatcher(new ProxyAgent(url));
+    installedProxy = { url, source };
+    return installedProxy;
+  } catch (error) {
+    installedProxy = null;
+    throw new Error(`Failed to install proxy ${url}: ${error?.message ?? error}`);
+  }
+}
+
+export function getInstalledProxy() {
+  return installedProxy;
+}

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -47,6 +47,7 @@ export function normalizeConfigKey(key) {
     tokentype: "tokenType",
     useragent: "userAgent",
     timezone: "timezone",
+    proxy: "proxy",
   };
 
   const condensed = String(key).replace(/[-_]/g, "").toLowerCase();


### PR DESCRIPTION
## Summary

- New `bgm proxy show|set|unset` subcommand and `proxy` config key (also settable via `bgm config set proxy ...`)
- Install `undici.ProxyAgent` as the global dispatcher at startup so all `fetch` calls (api.bgm.tv and next.bgm.tv/p1) route through the configured proxy
- Resolution priority: `config.proxy` > `BGM_PROXY` > `HTTPS_PROXY` > `https_proxy` > `HTTP_PROXY` > `http_proxy`
- `bgm config show` reports the effective proxy URL, source, and active state

## Motivation

Bangumi domains are unreachable on some networks without an HTTP proxy. Node's built-in `fetch` does not honor `HTTPS_PROXY` until Node 24's `--use-env-proxy` flag, so the currently supported `engines.node >=20` range has no built-in workaround. This adds first-class proxy support that works on Node 20+ without changes to call sites.

## Implementation

- `src/core/proxy.js` (new): `resolveProxyUrl()` + `installProxyFromConfig()` using `undici.ProxyAgent` + `setGlobalDispatcher`
- `src/core/config.js`: register `proxy` key, `BGM_PROXY` env mapping, and URL validation in `normalizeConfigValue` / env normalization
- `src/utils/helpers.js`: register `proxy` alias in `normalizeConfigKey`
- `src/cli.js`: install proxy at start of `main()`; add `bgm proxy` subcommand handler
- `src/core/output.js`: `formatProxyShow` formatter for non-JSON output of `bgm proxy show`
- `docs/features.zh-CN.md`: document new commands
- `.gitignore`: cover root `node_modules/` (subsumes the existing `oauth-backend/node_modules/`)
- `package.json`: add `undici` runtime dependency (zero transitive deps)

## Test plan

- [x] `node --test`: 51/51 pass
- [x] `bgm proxy set http://127.0.0.1:7897` → `bgm subject get 851` (沙耶の唄, R18) returns full data including `nsfw`, summary, rating
- [x] `bgm proxy unset` → CLI falls back to `HTTPS_PROXY` env var when set
- [x] `bgm proxy show` works in both plain and `--json` modes
- [x] `bgm auth status` succeeds via proxy

## Notes

- New runtime dep: `undici` (~ same code that ships inside Node, exposed as a public package; no transitive deps)
- Proxy URL is stored in user config (`~/.config/bgm-cli/config.json` or `%APPDATA%\bgm-cli\config.json`), never in the repo
- Only `http://` and `https://` proxies are validated. SOCKS proxies are out of scope (would need a different dispatcher implementation)