### PR TITLE
feat: multi-account profiles with quick switch and read-only --profile override

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -52,6 +52,19 @@ bgm auth set-token YOUR_ACCESS_TOKEN
 bgm auth token-status
 ```
 
+### Multiple accounts
+
+Snapshot the current credentials as a named profile and switch between accounts quickly:
+
+```bash
+bgm auth profile save main
+bgm auth profile list
+bgm auth profile use another
+bgm --profile another user me
+```
+
+`bgm --profile <name> <command>` runs a single command as that account without switching; it is a read-only override and never writes to disk.
+
 ### Proxy
 
 If your network needs a proxy to reach the Bangumi API reliably, configure an HTTP/HTTPS proxy for all CLI requests:

--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ bgm auth set-token YOUR_ACCESS_TOKEN
 bgm auth token-status
 ```
 
+### 多账户
+
+可以把当前凭据存成命名 profile，在多个账户之间快捷切换：
+
+```bash
+bgm auth profile save main
+bgm auth profile list
+bgm auth profile use another
+bgm --profile another user me
+```
+
+`bgm --profile <name> <command>` 只在单条命令内临时使用该账户，不切换、不写盘。
+
 ### 代理
 
 如果你所在网络访问 Bangumi API 不稳定，可以为所有 CLI 请求设置 HTTP/HTTPS 代理：

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -52,6 +52,19 @@ bgm auth set-token YOUR_ACCESS_TOKEN
 bgm auth token-status
 ```
 
+### 多帳戶
+
+可以把當前憑據存成命名 profile，在多個帳戶之間快捷切換：
+
+```bash
+bgm auth profile save main
+bgm auth profile list
+bgm auth profile use another
+bgm --profile another user me
+```
+
+`bgm --profile <name> <command>` 只在單條命令內臨時使用該帳戶，不切換、不寫盤。
+
 ### 代理
 
 如果你所在網路存取 Bangumi API 不穩定，可以為所有 CLI 請求設定 HTTP/HTTPS 代理：

--- a/docs/features.zh-CN.md
+++ b/docs/features.zh-CN.md
@@ -117,7 +117,7 @@ BGM_PROXY=http://127.0.0.1:7890 bgm subject search "Cowboy Bebop" --limit 1
 | `bgm auth set-session <chiiNextSessionID|cookie_string>` | 手动保存 private API session |
 | `bgm auth profile list` | 多账户：列出已保存的账户 profile（凭据脱敏显示）并标注当前活动 profile |
 | `bgm auth profile save <name> [--force]` | 多账户：把当前已保存的凭据快照存为命名 profile 并设为活动 profile；覆盖非活动 profile 需 `--force` |
-| `bgm auth profile use <name>` | 多账户：切换账户；先把当前凭据回存到原活动 profile，再载入目标 profile 的凭据 |
+| `bgm auth profile use <name> [--force]` | 多账户：切换账户；先把当前凭据回存到原活动 profile，再载入目标 profile 的凭据。当前凭据未存入任何 profile 且没有活动 profile 可回存时会拒绝切换，`--force` 表示确认丢弃 |
 | `bgm auth profile delete <name>` | 多账户：删除一个 profile 快照；删除活动 profile 时当前生效凭据保留 |
 
 说明：Access Token 与 Private Session 是两条独立渠道。对 `next.bgm.tv/p1` 请求，如果已保存 Private Session，CLI 会使用 session cookie，不会再同时发送 Access Token。

--- a/docs/features.zh-CN.md
+++ b/docs/features.zh-CN.md
@@ -115,8 +115,14 @@ BGM_PROXY=http://127.0.0.1:7890 bgm subject search "Cowboy Bebop" --limit 1
 | `bgm auth turnstile [--manual] [--listen-host <host>] [--port n] [--public-origin <url>] [--timeout-seconds <n>]` | 获取供下一次写入动作使用的短时 Turnstile Token |
 | `bgm auth session-login [--manual]` | 打开官方 private API 登录页并保存粘贴的辅助 session |
 | `bgm auth set-session <chiiNextSessionID|cookie_string>` | 手动保存 private API session |
+| `bgm auth profile list` | 多账户：列出已保存的账户 profile（凭据脱敏显示）并标注当前活动 profile |
+| `bgm auth profile save <name> [--force]` | 多账户：把当前已保存的凭据快照存为命名 profile 并设为活动 profile；覆盖非活动 profile 需 `--force` |
+| `bgm auth profile use <name>` | 多账户：切换账户；先把当前凭据回存到原活动 profile，再载入目标 profile 的凭据 |
+| `bgm auth profile delete <name>` | 多账户：删除一个 profile 快照；删除活动 profile 时当前生效凭据保留 |
 
 说明：Access Token 与 Private Session 是两条独立渠道。对 `next.bgm.tv/p1` 请求，如果已保存 Private Session，CLI 会使用 session cookie，不会再同时发送 Access Token。
+
+多账户说明：`bgm --profile <name> <command> ...` 可以在不切换账户的情况下临时以某个 profile 执行单条命令；该覆盖是只读的，所有会写入凭据的命令（login、set-token、auth clear、profile 写操作、`--init`、`tui` 等）在此模式下会拒绝执行。环境变量（如 `BGM_ACCESS_TOKEN`）优先级仍然最高，存在时相关输出会给出警告。
 
 ### 用户
 

--- a/docs/implementation.zh-CN.md
+++ b/docs/implementation.zh-CN.md
@@ -52,6 +52,16 @@
 3. 当前生效的运行时 `config.json`
 4. 环境变量
 
+### 多账户 profile
+
+`config.json` 中有两个保留键：`profiles`（命名凭据快照的嵌套对象）与 `activeProfile`（当前活动 profile 名）。顶层扁平凭据键的语义保持不变，始终代表"当前活动账户"；所有既有读写路径（login、set-token、clear 等）继续只操作顶层键。
+
+- `bgm auth profile use <name>` 采用切换时拷贝（copy-on-switch）：先把顶层凭据回存到原活动 profile（当前凭据为空时跳过回存，防止空快照覆盖），再把目标 profile 的凭据整组写到顶层，整个变更单次原子写盘。
+- `getConfig()` 的返回值会剔除 `profiles`，因此 `config show`（含 `--json`）与请求层永远接触不到其他账户的完整凭据。
+- `bgm --profile <name> <command>` 是只读覆盖：仅在本次进程内用该 profile 的凭据整组替换生效值，不写盘、不改 `activeProfile`；会写入凭据的命令在此模式下拒绝执行。
+- 环境变量优先级仍然最高：设置了 `BGM_ACCESS_TOKEN` 等变量时，profile 切换"看起来不生效"，相关命令输出会列出正在覆盖的变量名。
+- `profiles` 与 `activeProfile` 不在 `config set` 白名单内，只能通过 `bgm auth profile` 子命令操作。
+
 代理配置是一个例外：`config.proxy` 保持最高优先级，之后才读取代理环境变量。代理解析顺序为：
 
 ```text
@@ -72,6 +82,7 @@ config.proxy > BGM_PROXY > HTTPS_PROXY > https_proxy > HTTP_PROXY > http_proxy
 - `BGM_PROXY`
 - `HTTPS_PROXY` / `https_proxy`
 - `HTTP_PROXY` / `http_proxy`
+- `BGM_CONFIG_DIR`（特殊：不是配置值，而是配置目录覆盖，指定后强制使用该目录下的 `config.json` 并跳过全局/项目模式判断；仅在进程启动时读取，主要用于测试隔离）
 
 ## 输出模型
 
@@ -226,6 +237,10 @@ npm test
 - `test/smoke.test.js` — 基础冒烟测试：验证 `--version`、`--help`、各命令组 help 是否可正常打开
 - `test/public-api.test.js` — 公开 API 端到端测试：对 subject、user、group、blog、index、collection、status 等读接口做端到端检查
 - `test/calendar.test.js` — 番组表专项测试：集成测试和格式化单元测试
+- `test/profiles.test.js` — 多账户 profile 纯函数单元测试（快照挑选、名称校验、save/use/delete 变更计算、脱敏列表）
+- `test/profile-integration.test.js` — 多账户端到端测试：用 `BGM_CONFIG_DIR` 指向临时目录做完全隔离的 `spawnSync` 集成测试，含既有单账户输出的不变性守卫
+
+需要读写配置文件的集成测试应通过 `BGM_CONFIG_DIR` 指向 `mkdtemp` 临时目录做隔离，避免污染开发机的真实 `config.json`（`test/proxy.test.js` 与 `test/profile-integration.test.js` 是现成范例）。
 
 ### 发布流程
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aronnaxlin/bgm-cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aronnaxlin/bgm-cli",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "AGPL-3.0-only",
       "dependencies": {
         "undici": "^6.26.0"

--- a/skills/bgm-cli-operate/references/commands.md
+++ b/skills/bgm-cli-operate/references/commands.md
@@ -20,7 +20,14 @@ bgm --json config show
 bgm auth status
 bgm auth session-status
 bgm auth clear
+bgm --json auth profile list
+bgm auth profile save <name>
+bgm auth profile use <name>
+bgm auth profile delete <name>
+bgm --profile <name> <command> ...
 ```
+
+`bgm --profile <name>` runs one command as a saved account profile without switching; it is read-only and rejects credential-writing commands.
 
 Use `bgm --help` for the compact overview only. For detailed command discovery, prefer `bgm <group> --help`.
 

--- a/skills/bgm-cli-operate/references/install-and-auth.md
+++ b/skills/bgm-cli-operate/references/install-and-auth.md
@@ -146,6 +146,26 @@ To remove all saved auth state (Access Token, Refresh Token, Private Session) fo
 bgm auth clear
 ```
 
+`bgm auth clear` does not delete saved account profiles; run `bgm auth profile delete <name>` for those.
+
+## Multiple Accounts
+
+Named profiles snapshot one account's credentials each. The active credentials always live in the flat top-level config keys; switching copies them back into the previous profile first, then loads the target profile.
+
+```bash
+bgm auth profile save main
+bgm auth profile list
+bgm auth profile use another
+bgm auth profile delete old-account
+bgm --profile another user me
+```
+
+Operational notes:
+
+- `bgm --profile <name> <command>` is a read-only per-command override: it never writes to disk, and credential-writing commands (`auth login`, `auth set-token`, `auth clear`, `auth profile save/use/delete`, `--init`, `tui`, `config set <auth key>`) refuse to run with it
+- overwriting an existing non-active profile with `auth profile save` requires `--force`
+- auth environment variables such as `BGM_ACCESS_TOKEN` still win over any profile; the profile commands print a warning listing the overriding variables when they are set
+
 ## Turnstile Helper
 
 Group writes, timeline writes, and experimental blog comment writes may require a fresh Turnstile token.

--- a/src/cli.js
+++ b/src/cli.js
@@ -828,10 +828,10 @@ async function runAuthProfileCommand(options, context) {
     case "use": {
       ensureNoProfileOverride("bgm auth profile use");
       if (!name) {
-        throw new CommandError("Usage: bgm auth profile use <name>");
+        throw new CommandError("Usage: bgm auth profile use <name> [--force]");
       }
       const rawConfig = await readConfig();
-      const change = computeProfileSwitch(rawConfig, name);
+      const change = computeProfileSwitch(rawConfig, name, { force: toBoolean(options.force, false) });
       await replaceConfigValues(change);
       printResult(
         {

--- a/src/cli.js
+++ b/src/cli.js
@@ -13,6 +13,7 @@ import { BangumiClient, BangumiOAuthClient } from "./core/client.js";
 import { getInstalledProxy, installProxyFromConfig, resolveProxyUrl } from "./core/proxy.js";
 import { DEFAULT_TURNSTILE_TIMEOUT_MS, startTurnstileFlow } from "./core/turnstile.js";
 import {
+  AUTH_CONFIG_KEYS,
   ConfigError,
   clearConfigValue,
   clearConfigValues,
@@ -20,8 +21,12 @@ import {
   getConfig,
   getConfigFilePath,
   getConfigSourceFilePath,
+  getProfileOverride,
   normalizeConfigValue,
+  readConfig,
+  replaceConfigValues,
   setConfigValues,
+  setProfileOverride,
 } from "./core/config.js";
 import { CommandError, formatDisplayResult, printResult, printUsage } from "./core/output.js";
 import {
@@ -66,6 +71,13 @@ import {
   fallbackUserAgent,
   getPrivateLoginUrl,
 } from "./utils/auth.js";
+import {
+  buildProfileListPayload,
+  computeProfileDelete,
+  computeProfileSave,
+  computeProfileSwitch,
+  listAuthEnvOverrides,
+} from "./utils/profiles.js";
 import {
   getManagedInstallDir,
   getShellReloadHint,
@@ -113,16 +125,6 @@ const CLI_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(CLI_DIR, "..");
 
 const REMOTE_INSTALL_SCRIPT_BASE_URL = "https://raw.githubusercontent.com/aronnaxlin/bgm-cli/main/scripts";
-const AUTH_CONFIG_KEYS = [
-  "accessToken",
-  "refreshToken",
-  "tokenType",
-  "privateSessionId",
-  "privateSessionUpdatedAt",
-  "clientId",
-  "clientSecret",
-  "redirectUri",
-];
 
 async function main(argv) {
   const parsed = parseGlobalArgs(argv);
@@ -130,6 +132,11 @@ async function main(argv) {
     json: parsed.json,
     rawArgs: parsed.args,
   };
+
+  if (parsed.profile !== undefined) {
+    setProfileOverride(parsed.profile);
+    getConfig();
+  }
 
   try {
     installProxyFromConfig(getConfig());
@@ -143,6 +150,7 @@ async function main(argv) {
   }
 
   if (parsed.init) {
+    ensureNoProfileOverride("bgm --init");
     await runInitWizard(context);
     return;
   }
@@ -161,6 +169,7 @@ async function main(argv) {
 
   switch (group) {
     case "tui":
+      ensureNoProfileOverride("bgm tui");
       await runTui(context, { runConfigCommand, runSetupCommand });
       return;
     case "config":
@@ -414,6 +423,9 @@ async function runConfigCommand(command, args, context) {
       }
 
       const normalizedKey = normalizeConfigKey(key);
+      if (AUTH_CONFIG_KEYS.includes(normalizedKey)) {
+        ensureNoProfileOverride(`bgm config set ${normalizedKey}`);
+      }
       const normalizedValue = normalizeConfigValue(normalizedKey, value);
       await setConfigValues({ [normalizedKey]: normalizedValue });
       printResult(
@@ -433,6 +445,9 @@ async function runConfigCommand(command, args, context) {
       }
 
       const normalizedKey = normalizeConfigKey(key);
+      if (AUTH_CONFIG_KEYS.includes(normalizedKey)) {
+        ensureNoProfileOverride(`bgm config unset ${normalizedKey}`);
+      }
       await clearConfigValue(normalizedKey);
       printResult(
         {
@@ -521,6 +536,7 @@ async function runAuthCommand(command, args, context) {
 
   switch (command) {
     case "login": {
+      ensureNoProfileOverride("bgm auth login");
       const savedSessionId = getSavedPrivateSessionId(config);
       if (savedSessionId && !toBoolean(options.force, false)) {
         throw new CommandError("Private session is already saved. Run `bgm auth status` to inspect it, `bgm auth logout` to end it, or `bgm auth login --force` to replace it.");
@@ -562,6 +578,7 @@ async function runAuthCommand(command, args, context) {
       return;
     }
     case "logout": {
+      ensureNoProfileOverride("bgm auth logout");
       const sessionId = typeof config.privateSessionId === "string" ? config.privateSessionId.trim() : "";
       if (!sessionId) {
         throw new CommandError("No saved private API session. Run `bgm auth login` first, or use `bgm auth clear` to clear local auth state.");
@@ -602,6 +619,7 @@ async function runAuthCommand(command, args, context) {
       });
 
       if (toBoolean(options.save, false)) {
+        ensureNoProfileOverride("bgm auth token --save");
         await setConfigValues({
           clientId: options.clientId ?? config.clientId,
           clientSecret: options.clientSecret ?? config.clientSecret,
@@ -624,6 +642,7 @@ async function runAuthCommand(command, args, context) {
       });
 
       if (toBoolean(options.save, false)) {
+        ensureNoProfileOverride("bgm auth refresh --save");
         await setConfigValues({
           clientId: options.clientId ?? config.clientId,
           clientSecret: options.clientSecret ?? config.clientSecret,
@@ -670,11 +689,13 @@ async function runAuthCommand(command, args, context) {
       return;
     }
     case "session-login": {
+      ensureNoProfileOverride("bgm auth session-login");
       const result = await runPrivateSessionLogin(options, context);
       printResult(result, context);
       return;
     }
     case "set-token": {
+      ensureNoProfileOverride("bgm auth set-token");
       const accessToken = options.accessToken ?? firstPositional(options);
       if (!accessToken) {
         throw new CommandError("Usage: bgm auth set-token <access_token>");
@@ -696,6 +717,7 @@ async function runAuthCommand(command, args, context) {
       return;
     }
     case "set-session": {
+      ensureNoProfileOverride("bgm auth set-session");
       const rawSession = options.session ?? firstPositional(options);
       if (!rawSession) {
         throw new CommandError("Usage: bgm auth set-session <chiiNextSessionID|cookie_string>");
@@ -738,20 +760,126 @@ async function runAuthCommand(command, args, context) {
       return;
     }
     case "clear": {
+      ensureNoProfileOverride("bgm auth clear");
       const clearKeys = resolveAuthClearKeys(options);
-      await clearConfigValues(clearKeys);
+      const rawConfig = await readConfig();
+      const isFullClear = AUTH_CONFIG_KEYS.every((key) => clearKeys.includes(key));
+      const keys = isFullClear && rawConfig.activeProfile !== undefined
+        ? [...clearKeys, "activeProfile"]
+        : clearKeys;
+      await clearConfigValues(keys);
       printResult(
         {
           resource: "auth-clear",
-          cleared: clearKeys,
+          cleared: keys,
           configFile: getConfigFilePath(),
         },
         context,
       );
       return;
     }
+    case "profile": {
+      await runAuthProfileCommand(options, context);
+      return;
+    }
     default:
-      throw new CommandError("Usage: bgm auth <login|logout|status|token-status|login-url|token|refresh|turnstile|session-login|set-token|set-session|session-status|clear> ...");
+      throw new CommandError("Usage: bgm auth <login|logout|status|token-status|login-url|token|refresh|turnstile|session-login|set-token|set-session|session-status|clear|profile> ...");
+  }
+}
+
+async function runAuthProfileCommand(options, context) {
+  const subcommand = getPositional(options, 0);
+  const name = getPositional(options, 1);
+
+  switch (subcommand) {
+    case "list": {
+      const rawConfig = await readConfig();
+      printResult(
+        buildProfileListPayload(rawConfig, {
+          configFile: getConfigFilePath(),
+          envOverrides: listAuthEnvOverrides(),
+          profileOverride: getProfileOverride(),
+        }),
+        context,
+      );
+      return;
+    }
+    case "save": {
+      ensureNoProfileOverride("bgm auth profile save");
+      if (!name) {
+        throw new CommandError("Usage: bgm auth profile save <name> [--force]");
+      }
+      const rawConfig = await readConfig();
+      const change = computeProfileSave(rawConfig, name, { force: toBoolean(options.force, false) });
+      await replaceConfigValues(change);
+      printResult(
+        {
+          resource: "auth-profile-mutation",
+          action: "save",
+          profile: change.profile,
+          activeProfile: change.profile,
+          configFile: getConfigFilePath(),
+          envOverrides: listAuthEnvOverrides(),
+        },
+        context,
+      );
+      return;
+    }
+    case "use": {
+      ensureNoProfileOverride("bgm auth profile use");
+      if (!name) {
+        throw new CommandError("Usage: bgm auth profile use <name>");
+      }
+      const rawConfig = await readConfig();
+      const change = computeProfileSwitch(rawConfig, name);
+      await replaceConfigValues(change);
+      printResult(
+        {
+          resource: "auth-profile-mutation",
+          action: "use",
+          profile: change.profile,
+          activeProfile: change.profile,
+          previousProfile: change.previousProfile,
+          syncedPrevious: change.syncedPrevious,
+          configFile: getConfigFilePath(),
+          envOverrides: listAuthEnvOverrides(),
+        },
+        context,
+      );
+      return;
+    }
+    case "delete": {
+      ensureNoProfileOverride("bgm auth profile delete");
+      if (!name) {
+        throw new CommandError("Usage: bgm auth profile delete <name>");
+      }
+      const rawConfig = await readConfig();
+      const change = computeProfileDelete(rawConfig, name);
+      await replaceConfigValues(change);
+      printResult(
+        {
+          resource: "auth-profile-mutation",
+          action: "delete",
+          profile: change.profile,
+          activeProfile: change.wasActive ? null : (typeof rawConfig.activeProfile === "string" ? rawConfig.activeProfile : null),
+          ...(change.wasActive ? { credentialsRetained: true } : {}),
+          configFile: getConfigFilePath(),
+          envOverrides: listAuthEnvOverrides(),
+        },
+        context,
+      );
+      return;
+    }
+    default:
+      throw new CommandError("Usage: bgm auth profile <list|save|use|delete> ...");
+  }
+}
+
+function ensureNoProfileOverride(actionLabel) {
+  if (getProfileOverride()) {
+    throw new CommandError(
+      `--profile is a read-only account override; \`${actionLabel}\` would modify saved credentials. Run \`bgm auth profile use <name>\` to switch accounts instead.`,
+    );
   }
 }
 
@@ -787,10 +915,16 @@ function buildAuthStatusPayload(config) {
   const accessToken = typeof config.accessToken === "string" ? config.accessToken.trim() : "";
   const refreshToken = typeof config.refreshToken === "string" ? config.refreshToken.trim() : "";
   const privateSession = getSavedPrivateSessionId(config);
+  const activeProfile = typeof config.activeProfile === "string" && config.activeProfile.trim() !== ""
+    ? config.activeProfile.trim()
+    : null;
+  const profileOverride = getProfileOverride();
 
   return {
     resource: "auth-status",
     configFile: getConfigFilePath(),
+    ...(activeProfile ? { activeProfile } : {}),
+    ...(profileOverride ? { profileOverride } : {}),
     policy: "p1 requests use the private session cookie when saved; Access Token is not sent together with it.",
     channels: {
       accessToken: {

--- a/src/core/config.js
+++ b/src/core/config.js
@@ -30,6 +30,27 @@ const DEFAULT_CONFIG = {
   timezone: "Asia/Shanghai",
 };
 
+export const AUTH_CONFIG_KEYS = [
+  "accessToken",
+  "refreshToken",
+  "tokenType",
+  "privateSessionId",
+  "privateSessionUpdatedAt",
+  "clientId",
+  "clientSecret",
+  "redirectUri",
+];
+
+let profileOverrideName = null;
+
+export function setProfileOverride(name) {
+  profileOverrideName = typeof name === "string" && name.trim() !== "" ? name.trim() : null;
+}
+
+export function getProfileOverride() {
+  return profileOverrideName;
+}
+
 const ENV_TO_KEY = {
   BGM_ACCESS_TOKEN: "accessToken",
   BGM_REFRESH_TOKEN: "refreshToken",
@@ -55,7 +76,7 @@ export function getConfigSourceFilePath() {
 }
 
 export function getConfig() {
-  const runtimeConfig = getActiveRuntimeConfigMeta().config;
+  const { profiles, ...runtimeConfig } = getActiveRuntimeConfigMeta().config;
   const devConfig = readEnvConfigFileSafe(DEV_ENV_FILE);
   const envConfig = {};
 
@@ -66,12 +87,29 @@ export function getConfig() {
     }
   }
 
-  const merged = {
-    ...DEFAULT_CONFIG,
-    ...devConfig,
-    ...runtimeConfig,
-    ...envConfig,
-  };
+  let overlay = null;
+  if (profileOverrideName) {
+    const snapshot = isPlainObject(profiles) ? profiles[profileOverrideName] : undefined;
+    if (!isPlainObject(snapshot)) {
+      throw new ConfigError(`Profile not found: ${profileOverrideName}`);
+    }
+    overlay = pickAuthConfigKeys(snapshot);
+  }
+
+  const merged = overlay
+    ? {
+        ...DEFAULT_CONFIG,
+        ...omitAuthConfigKeys(devConfig),
+        ...omitAuthConfigKeys(runtimeConfig),
+        ...overlay,
+        ...envConfig,
+      }
+    : {
+        ...DEFAULT_CONFIG,
+        ...devConfig,
+        ...runtimeConfig,
+        ...envConfig,
+      };
 
   return {
     ...merged,
@@ -181,6 +219,22 @@ export async function clearConfigValues(keys) {
   await writeFile(configFile, `${JSON.stringify(current, null, 2)}\n`, "utf8");
 }
 
+export async function replaceConfigValues({ set = {}, remove = [] } = {}) {
+  const runtimeMeta = getActiveRuntimeConfigMeta();
+  const configFile = runtimeMeta.writeFile;
+  const configDir = path.dirname(configFile);
+  const current = { ...runtimeMeta.config };
+
+  for (const key of remove) {
+    delete current[key];
+  }
+
+  const next = { ...current, ...set };
+
+  await mkdir(configDir, { recursive: true });
+  await writeFile(configFile, `${JSON.stringify(next, null, 2)}\n`, "utf8");
+}
+
 export async function readConfig() {
   return getActiveRuntimeConfigMeta().config;
 }
@@ -224,10 +278,48 @@ export async function enableGlobalConfigMode() {
 }
 
 function getActiveRuntimeConfigMeta() {
+  if (hasConfigDirOverride()) {
+    const userState = readJsonFileState(USER_CONFIG_FILE);
+    if (userState.exists && !userState.ok) {
+      throw new ConfigError(`Failed to parse global config file: ${USER_CONFIG_FILE}`);
+    }
+    return {
+      config: userState.value,
+      sourceFile: USER_CONFIG_FILE,
+      writeFile: USER_CONFIG_FILE,
+    };
+  }
   if (isGlobalInstallEnabled() || isPackageInstall()) {
     return getGlobalRuntimeConfigMeta();
   }
   return getProjectRuntimeConfigMeta();
+}
+
+function hasConfigDirOverride() {
+  const value = process.env.BGM_CONFIG_DIR;
+  return typeof value === "string" && value.trim() !== "";
+}
+
+function pickAuthConfigKeys(source) {
+  const result = {};
+  for (const key of AUTH_CONFIG_KEYS) {
+    if (source[key] !== undefined) {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
+
+function omitAuthConfigKeys(source) {
+  const result = { ...source };
+  for (const key of AUTH_CONFIG_KEYS) {
+    delete result[key];
+  }
+  return result;
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
 function getGlobalRuntimeConfigMeta() {
@@ -291,6 +383,11 @@ function isPackageInstall() {
 }
 
 function resolveUserConfigDir() {
+  const overrideDir = process.env.BGM_CONFIG_DIR;
+  if (typeof overrideDir === "string" && overrideDir.trim() !== "") {
+    return path.resolve(overrideDir.trim());
+  }
+
   if (process.platform === "win32" && process.env.APPDATA) {
     return path.join(process.env.APPDATA, "bgm-cli");
   }

--- a/src/core/output.js
+++ b/src/core/output.js
@@ -88,6 +88,14 @@ function buildUsageText(target) {
         ["bgm [--json] auth turnstile [--manual] [--listen-host <host>] [--port n] [--public-origin <url>] [--timeout-seconds <n>]", "Prefer the hosted official Bangumi Turnstile flow and fall back to the local helper when needed."],
         ["bgm auth session-login [--manual]", "Private session helper: open the official private API login page and save a pasted chiiNextSessionID."],
         ["bgm [--json] auth set-session <chiiNextSessionID|cookie_string>", "Save a private API session cookie value for p1 requests."],
+        ["bgm [--json] auth profile list", "List saved account profiles with masked previews and the active profile."],
+        ["bgm [--json] auth profile save <name> [--force]", "Snapshot the current saved credentials into a named profile and mark it active."],
+        ["bgm [--json] auth profile use <name>", "Sync current credentials back to the active profile, then load the named profile."],
+        ["bgm [--json] auth profile delete <name>", "Delete one saved profile snapshot. Active credentials are kept."],
+      ], [
+        "Profiles",
+        "  Run one command as a saved profile without switching: `bgm --profile <name> <command> ...`.",
+        "  The override is read-only; credential-writing commands refuse to run with it.",
       ]);
     case "config":
       return buildGroupUsage("Config", [
@@ -297,6 +305,7 @@ function buildMainUsage() {
 
 Usage
   bgm <command> [subcommand] [options]
+  bgm --profile <name> <command> [subcommand] [options]
   bgm <command> --help
 
 Core
@@ -466,6 +475,14 @@ export function formatDisplayResult(value, context = {}) {
 
   if (isAuthClearPayload(value)) {
     return formatAuthClear(value);
+  }
+
+  if (isAuthProfileListPayload(value)) {
+    return formatAuthProfileList(value);
+  }
+
+  if (isAuthProfileMutationPayload(value)) {
+    return formatAuthProfileMutation(value);
   }
 
   if (isBlogListPayload(value)) {
@@ -790,6 +807,8 @@ function formatAuthStatus(payload) {
   return [
     "Auth status",
     `  Config file: ${payload.configFile ?? "-"}`,
+    payload.activeProfile ? `  Active profile: ${payload.activeProfile}` : null,
+    payload.profileOverride ? `  Profile override (--profile): ${payload.profileOverride}` : null,
     payload.policy ? `  Policy: ${payload.policy}` : null,
     "",
     "Access Token channel",
@@ -890,6 +909,68 @@ function formatAuthClear(payload) {
     `  Cleared: ${Array.isArray(payload.cleared) ? payload.cleared.join(", ") : "-"}`,
     "  Preserved: oauthServerBaseUrl, app metadata, timezone, and other non-auth config",
   ].join("\n");
+}
+
+function formatAuthProfileList(payload) {
+  const lines = [
+    "Auth profiles",
+    `  Config file: ${payload.configFile ?? "-"}`,
+    `  Active profile: ${payload.activeProfile ?? "-"}`,
+  ];
+
+  if (payload.profileOverride) {
+    lines.push(`  Profile override (--profile): ${payload.profileOverride}`);
+  }
+  if (payload.activeProfileMissing) {
+    lines.push("  Note: the active profile points to a missing snapshot.");
+  }
+
+  if (payload.profiles.length === 0) {
+    lines.push("  Profiles: none. Run `bgm auth profile save <name>` to snapshot the current credentials.");
+  } else {
+    lines.push("  Profiles:");
+    for (const profile of payload.profiles) {
+      lines.push(`    ${profile.name}${profile.active ? " (active)" : ""}`);
+      lines.push(`      Access token: ${profile.accessTokenSaved ? profile.accessTokenPreview : "-"}`);
+      lines.push(`      Private session: ${profile.privateSessionSaved ? profile.privateSessionPreview : "-"}`);
+      if (profile.privateSessionUpdatedAt) {
+        lines.push(`      Session updated at: ${formatTimestamp(profile.privateSessionUpdatedAt)}`);
+      }
+    }
+  }
+
+  appendEnvOverrideWarning(lines, payload.envOverrides);
+  return lines.join("\n");
+}
+
+function formatAuthProfileMutation(payload) {
+  const titles = {
+    save: "Auth profile saved",
+    use: "Auth profile switched",
+    delete: "Auth profile deleted",
+  };
+  const lines = [
+    titles[payload.action] ?? "Auth profile updated",
+    `  Profile: ${payload.profile}`,
+    `  Active profile: ${payload.activeProfile ?? "-"}`,
+    `  Config file: ${payload.configFile ?? "-"}`,
+  ];
+
+  if (payload.action === "use" && payload.previousProfile && payload.previousProfile !== payload.profile) {
+    lines.push(`  Previous profile: ${payload.previousProfile}${payload.syncedPrevious ? " (snapshot updated)" : ""}`);
+  }
+  if (payload.credentialsRetained) {
+    lines.push("  Active credentials are kept; run `bgm auth clear` to remove them.");
+  }
+
+  appendEnvOverrideWarning(lines, payload.envOverrides);
+  return lines.join("\n");
+}
+
+function appendEnvOverrideWarning(lines, envOverrides) {
+  if (Array.isArray(envOverrides) && envOverrides.length > 0) {
+    lines.push(`  Warning: environment variables override saved credentials: ${envOverrides.join(", ")}`);
+  }
 }
 
 function formatStatusIncidents(payload) {
@@ -3612,6 +3693,14 @@ function isAuthLogoutPayload(value) {
 
 function isAuthClearPayload(value) {
   return isObject(value) && value.resource === "auth-clear" && Array.isArray(value.cleared);
+}
+
+function isAuthProfileListPayload(value) {
+  return isObject(value) && value.resource === "auth-profile-list" && Array.isArray(value.profiles);
+}
+
+function isAuthProfileMutationPayload(value) {
+  return isObject(value) && value.resource === "auth-profile-mutation" && typeof value.action === "string";
 }
 
 function isStatusIncidentsPayload(value) {

--- a/src/core/output.js
+++ b/src/core/output.js
@@ -90,7 +90,7 @@ function buildUsageText(target) {
         ["bgm [--json] auth set-session <chiiNextSessionID|cookie_string>", "Save a private API session cookie value for p1 requests."],
         ["bgm [--json] auth profile list", "List saved account profiles with masked previews and the active profile."],
         ["bgm [--json] auth profile save <name> [--force]", "Snapshot the current saved credentials into a named profile and mark it active."],
-        ["bgm [--json] auth profile use <name>", "Sync current credentials back to the active profile, then load the named profile."],
+        ["bgm [--json] auth profile use <name> [--force]", "Sync current credentials back to the active profile, then load the named profile. --force discards unsaved credentials."],
         ["bgm [--json] auth profile delete <name>", "Delete one saved profile snapshot. Active credentials are kept."],
       ], [
         "Profiles",

--- a/src/utils/args.js
+++ b/src/utils/args.js
@@ -2,13 +2,17 @@
  * CLI argument parsing utilities.
  */
 
+import { CommandError } from "../core/output.js";
+
 export function parseGlobalArgs(argv) {
   const args = [];
   let json = false;
   let init = false;
   let version = false;
+  let profile;
 
-  for (const arg of argv) {
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
     if (arg === "--json") {
       json = true;
       continue;
@@ -21,10 +25,27 @@ export function parseGlobalArgs(argv) {
       version = true;
       continue;
     }
+    if (arg === "--profile") {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new CommandError("Usage: bgm --profile <name> <command> ...");
+      }
+      profile = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--profile=")) {
+      const value = arg.slice("--profile=".length);
+      if (value === "") {
+        throw new CommandError("Usage: bgm --profile <name> <command> ...");
+      }
+      profile = value;
+      continue;
+    }
     args.push(arg);
   }
 
-  return { args, json, init, version };
+  return { args, json, init, version, profile };
 }
 
 export function parseFlags(args) {

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -1,0 +1,175 @@
+import process from "node:process";
+import { AUTH_CONFIG_KEYS } from "../core/config.js";
+import { CommandError } from "../core/output.js";
+import { hasSavedConfigValue, previewToken } from "./helpers.js";
+
+export const PROFILE_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,31}$/;
+
+const AUTH_ENV_OVERRIDE_NAMES = [
+  "BGM_ACCESS_TOKEN",
+  "BGM_REFRESH_TOKEN",
+  "BGM_PRIVATE_SESSION_ID",
+  "BGM_CLIENT_ID",
+  "BGM_CLIENT_SECRET",
+  "BGM_REDIRECT_URI",
+];
+
+export function validateProfileName(name) {
+  const value = typeof name === "string" ? name.trim() : "";
+  if (!PROFILE_NAME_PATTERN.test(value)) {
+    throw new CommandError(
+      `Invalid profile name: ${String(name ?? "")}. Names must match [A-Za-z0-9][A-Za-z0-9._-]{0,31}.`,
+    );
+  }
+  return value;
+}
+
+export function pickAuthSnapshot(source) {
+  const snapshot = {};
+  if (!isPlainObject(source)) {
+    return snapshot;
+  }
+  for (const key of AUTH_CONFIG_KEYS) {
+    if (source[key] !== undefined) {
+      snapshot[key] = source[key];
+    }
+  }
+  return snapshot;
+}
+
+export function snapshotHasCredentials(snapshot) {
+  return hasSavedConfigValue(snapshot?.accessToken) || hasSavedConfigValue(snapshot?.privateSessionId);
+}
+
+export function computeProfileSave(rawConfig, name, { force = false } = {}) {
+  const profileName = validateProfileName(name);
+  const profiles = readProfilesMap(rawConfig);
+  const snapshot = pickAuthSnapshot(rawConfig);
+  if (!snapshotHasCredentials(snapshot)) {
+    throw new CommandError(
+      "No saved auth credentials to snapshot. Run `bgm auth login` or `bgm auth set-token` first.",
+    );
+  }
+  const activeProfile = readActiveProfile(rawConfig);
+  if (profiles[profileName] !== undefined && profileName !== activeProfile && !force) {
+    throw new CommandError(`Profile already exists: ${profileName}. Pass --force to overwrite it.`);
+  }
+  return {
+    set: {
+      profiles: { ...profiles, [profileName]: snapshot },
+      activeProfile: profileName,
+    },
+    remove: [],
+    profile: profileName,
+  };
+}
+
+export function computeProfileSwitch(rawConfig, name) {
+  const profileName = validateProfileName(name);
+  const profiles = readProfilesMap(rawConfig);
+  if (profiles[profileName] === undefined) {
+    throw profileNotFoundError(profileName, profiles);
+  }
+  const activeProfile = readActiveProfile(rawConfig);
+  const currentSnapshot = pickAuthSnapshot(rawConfig);
+  const syncedPrevious = Boolean(activeProfile) && snapshotHasCredentials(currentSnapshot);
+  const nextProfiles = { ...profiles };
+  if (syncedPrevious) {
+    nextProfiles[activeProfile] = currentSnapshot;
+  }
+  const targetSnapshot = pickAuthSnapshot(nextProfiles[profileName]);
+  const remove = AUTH_CONFIG_KEYS.filter((key) => targetSnapshot[key] === undefined);
+  return {
+    set: {
+      ...targetSnapshot,
+      profiles: nextProfiles,
+      activeProfile: profileName,
+    },
+    remove,
+    profile: profileName,
+    previousProfile: activeProfile || null,
+    syncedPrevious,
+  };
+}
+
+export function computeProfileDelete(rawConfig, name) {
+  const profileName = validateProfileName(name);
+  const profiles = readProfilesMap(rawConfig);
+  if (profiles[profileName] === undefined) {
+    throw profileNotFoundError(profileName, profiles);
+  }
+  const nextProfiles = { ...profiles };
+  delete nextProfiles[profileName];
+  const wasActive = readActiveProfile(rawConfig) === profileName;
+  return {
+    set: { profiles: nextProfiles },
+    remove: wasActive ? ["activeProfile"] : [],
+    profile: profileName,
+    wasActive,
+  };
+}
+
+export function buildProfileListPayload(rawConfig, { configFile, envOverrides = [], profileOverride = null } = {}) {
+  const profilesMap = readProfilesMap(rawConfig);
+  const activeProfile = readActiveProfile(rawConfig) || null;
+  const profiles = Object.keys(profilesMap).sort().map((name) => {
+    const snapshot = pickAuthSnapshot(profilesMap[name]);
+    const accessTokenSaved = hasSavedConfigValue(snapshot.accessToken);
+    const privateSessionSaved = hasSavedConfigValue(snapshot.privateSessionId);
+    return {
+      name,
+      active: name === activeProfile,
+      accessTokenSaved,
+      accessTokenPreview: accessTokenSaved ? previewToken(snapshot.accessToken) : null,
+      refreshTokenSaved: hasSavedConfigValue(snapshot.refreshToken),
+      privateSessionSaved,
+      privateSessionPreview: privateSessionSaved ? previewToken(snapshot.privateSessionId) : null,
+      privateSessionUpdatedAt: snapshot.privateSessionUpdatedAt ?? null,
+    };
+  });
+  return {
+    resource: "auth-profile-list",
+    configFile: configFile ?? null,
+    activeProfile,
+    activeProfileMissing: Boolean(activeProfile && profilesMap[activeProfile] === undefined),
+    ...(profileOverride ? { profileOverride } : {}),
+    envOverrides,
+    profiles,
+  };
+}
+
+export function listAuthEnvOverrides(env = process.env) {
+  return AUTH_ENV_OVERRIDE_NAMES.filter((envName) => {
+    const value = env[envName];
+    return typeof value === "string" && value.trim() !== "";
+  });
+}
+
+function readProfilesMap(rawConfig) {
+  const profiles = rawConfig?.profiles;
+  if (!isPlainObject(profiles)) {
+    return {};
+  }
+  const result = {};
+  for (const [name, snapshot] of Object.entries(profiles)) {
+    if (isPlainObject(snapshot)) {
+      result[name] = snapshot;
+    }
+  }
+  return result;
+}
+
+function readActiveProfile(rawConfig) {
+  return typeof rawConfig?.activeProfile === "string" ? rawConfig.activeProfile.trim() : "";
+}
+
+function profileNotFoundError(name, profilesMap) {
+  const names = Object.keys(profilesMap).sort();
+  return new CommandError(
+    `Profile not found: ${name}. Saved profiles: ${names.length > 0 ? names.join(", ") : "(none)"}`,
+  );
+}
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}

--- a/src/utils/profiles.js
+++ b/src/utils/profiles.js
@@ -51,7 +51,7 @@ export function computeProfileSave(rawConfig, name, { force = false } = {}) {
     );
   }
   const activeProfile = readActiveProfile(rawConfig);
-  if (profiles[profileName] !== undefined && profileName !== activeProfile && !force) {
+  if (hasProfile(profiles, profileName) && profileName !== activeProfile && !force) {
     throw new CommandError(`Profile already exists: ${profileName}. Pass --force to overwrite it.`);
   }
   return {
@@ -64,15 +64,26 @@ export function computeProfileSave(rawConfig, name, { force = false } = {}) {
   };
 }
 
-export function computeProfileSwitch(rawConfig, name) {
+export function computeProfileSwitch(rawConfig, name, { force = false } = {}) {
   const profileName = validateProfileName(name);
   const profiles = readProfilesMap(rawConfig);
-  if (profiles[profileName] === undefined) {
+  if (!hasProfile(profiles, profileName)) {
     throw profileNotFoundError(profileName, profiles);
+  }
+  if (!snapshotHasCredentials(pickAuthSnapshot(profiles[profileName]))) {
+    throw new CommandError(
+      `Profile has no saved credentials: ${profileName}. Switching to it would leave you signed out; run \`bgm auth profile delete ${profileName}\` and save it again.`,
+    );
   }
   const activeProfile = readActiveProfile(rawConfig);
   const currentSnapshot = pickAuthSnapshot(rawConfig);
   const syncedPrevious = Boolean(activeProfile) && snapshotHasCredentials(currentSnapshot);
+  if (!syncedPrevious && snapshotHasCredentials(currentSnapshot) && !force
+    && !isSnapshotSavedIn(profiles, currentSnapshot)) {
+    throw new CommandError(
+      "The current credentials are not stored in any profile, and no active profile is set to sync them back into; switching would discard them. Run `bgm auth profile save <name>` first, or pass --force to discard them.",
+    );
+  }
   const nextProfiles = { ...profiles };
   if (syncedPrevious) {
     nextProfiles[activeProfile] = currentSnapshot;
@@ -95,7 +106,7 @@ export function computeProfileSwitch(rawConfig, name) {
 export function computeProfileDelete(rawConfig, name) {
   const profileName = validateProfileName(name);
   const profiles = readProfilesMap(rawConfig);
-  if (profiles[profileName] === undefined) {
+  if (!hasProfile(profiles, profileName)) {
     throw profileNotFoundError(profileName, profiles);
   }
   const nextProfiles = { ...profiles };
@@ -131,7 +142,7 @@ export function buildProfileListPayload(rawConfig, { configFile, envOverrides = 
     resource: "auth-profile-list",
     configFile: configFile ?? null,
     activeProfile,
-    activeProfileMissing: Boolean(activeProfile && profilesMap[activeProfile] === undefined),
+    activeProfileMissing: Boolean(activeProfile && !hasProfile(profilesMap, activeProfile)),
     ...(profileOverride ? { profileOverride } : {}),
     envOverrides,
     profiles,
@@ -157,6 +168,23 @@ function readProfilesMap(rawConfig) {
     }
   }
   return result;
+}
+
+function hasProfile(profiles, name) {
+  return Object.hasOwn(profiles, name);
+}
+
+function isSnapshotSavedIn(profiles, snapshot) {
+  return Object.values(profiles).some((saved) => sameCredentials(pickAuthSnapshot(saved), snapshot));
+}
+
+function sameCredentials(left, right) {
+  return credentialValue(left.accessToken) === credentialValue(right.accessToken)
+    && credentialValue(left.privateSessionId) === credentialValue(right.privateSessionId);
+}
+
+function credentialValue(value) {
+  return typeof value === "string" ? value.trim() : "";
 }
 
 function readActiveProfile(rawConfig) {

--- a/test/auth-output.test.js
+++ b/test/auth-output.test.js
@@ -31,6 +31,114 @@ describe("auth output", () => {
     assert.match(output, /Validate: bgm auth token-status/);
     assert.match(output, /Private session channel/);
     assert.match(output, /Login: bgm auth login/);
+    assert.ok(!output.includes("Active profile"));
+    assert.ok(!output.includes("Profile override"));
+  });
+
+  it("should show active profile and override lines only when present", () => {
+    const output = formatDisplayResult({
+      resource: "auth-status",
+      configFile: "/tmp/config.json",
+      activeProfile: "main",
+      profileOverride: "alt",
+      channels: {
+        accessToken: { saved: false },
+        privateSession: { saved: false },
+      },
+    });
+
+    assert.match(output, /Active profile: main/);
+    assert.match(output, /Profile override \(--profile\): alt/);
+  });
+
+  it("should format the auth profile list with masked previews", () => {
+    const output = formatDisplayResult({
+      resource: "auth-profile-list",
+      configFile: "/tmp/config.json",
+      activeProfile: "main",
+      activeProfileMissing: false,
+      envOverrides: ["BGM_ACCESS_TOKEN"],
+      profiles: [
+        {
+          name: "main",
+          active: true,
+          accessTokenSaved: true,
+          accessTokenPreview: "abc123...wxyz",
+          refreshTokenSaved: false,
+          privateSessionSaved: false,
+          privateSessionPreview: null,
+          privateSessionUpdatedAt: null,
+        },
+        {
+          name: "alt",
+          active: false,
+          accessTokenSaved: false,
+          accessTokenPreview: null,
+          refreshTokenSaved: false,
+          privateSessionSaved: true,
+          privateSessionPreview: "sess12...89ab",
+          privateSessionUpdatedAt: "2026-08-01T00:00:00.000Z",
+        },
+      ],
+    });
+
+    assert.match(output, /Auth profiles/);
+    assert.match(output, /main \(active\)/);
+    assert.match(output, /abc123\.\.\.wxyz/);
+    assert.match(output, /sess12\.\.\.89ab/);
+    assert.match(output, /Warning: environment variables override saved credentials: BGM_ACCESS_TOKEN/);
+  });
+
+  it("should format an empty auth profile list with a hint", () => {
+    const output = formatDisplayResult({
+      resource: "auth-profile-list",
+      configFile: "/tmp/config.json",
+      activeProfile: null,
+      activeProfileMissing: false,
+      envOverrides: [],
+      profiles: [],
+    });
+
+    assert.match(output, /Profiles: none/);
+    assert.match(output, /bgm auth profile save <name>/);
+  });
+
+  it("should format profile save, use, and delete mutations", () => {
+    const save = formatDisplayResult({
+      resource: "auth-profile-mutation",
+      action: "save",
+      profile: "main",
+      activeProfile: "main",
+      configFile: "/tmp/config.json",
+      envOverrides: [],
+    });
+    assert.match(save, /Auth profile saved/);
+    assert.match(save, /Profile: main/);
+
+    const use = formatDisplayResult({
+      resource: "auth-profile-mutation",
+      action: "use",
+      profile: "alt",
+      activeProfile: "alt",
+      previousProfile: "main",
+      syncedPrevious: true,
+      configFile: "/tmp/config.json",
+      envOverrides: [],
+    });
+    assert.match(use, /Auth profile switched/);
+    assert.match(use, /Previous profile: main \(snapshot updated\)/);
+
+    const removed = formatDisplayResult({
+      resource: "auth-profile-mutation",
+      action: "delete",
+      profile: "main",
+      activeProfile: null,
+      credentialsRetained: true,
+      configFile: "/tmp/config.json",
+      envOverrides: [],
+    });
+    assert.match(removed, /Auth profile deleted/);
+    assert.match(removed, /Active credentials are kept/);
   });
 });
 

--- a/test/profile-integration.test.js
+++ b/test/profile-integration.test.js
@@ -1,0 +1,199 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { AUTH_CONFIG_KEYS } from "../src/core/config.js";
+
+const CLI = "node";
+const CLI_ARGS = ["src/cli.js"];
+const TOKEN_A = "fixtureTokenAxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+const TOKEN_B = "fixtureTokenBxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+const SESSION_A = "fixtureSessionAxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+function makeConfigDir(fixture) {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "bgm-profile-test-"));
+  writeFileSync(path.join(dir, "config.json"), `${JSON.stringify(fixture, null, 2)}\n`, "utf8");
+  return dir;
+}
+
+function readConfigFile(dir) {
+  return JSON.parse(readFileSync(path.join(dir, "config.json"), "utf8"));
+}
+
+function run(args, configDir, extraEnv = {}) {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key.startsWith("BGM_")) {
+      delete env[key];
+    }
+  }
+  env.BGM_CONFIG_DIR = configDir;
+  Object.assign(env, extraEnv);
+  return spawnSync(CLI, [...CLI_ARGS, ...args], {
+    encoding: "utf-8",
+    cwd: process.cwd(),
+    env,
+  });
+}
+
+function baseFixture(extra = {}) {
+  return {
+    accessToken: TOKEN_A,
+    tokenType: "Bearer",
+    privateSessionId: SESSION_A,
+    ...extra,
+  };
+}
+
+describe("auth profile integration", () => {
+  it("saves the current credentials as a named profile", () => {
+    const dir = makeConfigDir(baseFixture());
+    const result = run(["auth", "profile", "save", "main"], dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    const config = readConfigFile(dir);
+    assert.strictEqual(config.activeProfile, "main");
+    assert.strictEqual(config.profiles.main.accessToken, TOKEN_A);
+    assert.strictEqual(config.profiles.main.privateSessionId, SESSION_A);
+    assert.strictEqual(config.accessToken, TOKEN_A);
+  });
+
+  it("switches accounts and syncs the previous profile snapshot", () => {
+    const dir = makeConfigDir(baseFixture());
+    assert.strictEqual(run(["auth", "profile", "save", "main"], dir).status, 0);
+    assert.strictEqual(run(["auth", "set-token", TOKEN_B], dir).status, 0);
+    assert.strictEqual(run(["auth", "profile", "save", "alt"], dir).status, 0);
+    const use = run(["auth", "profile", "use", "main"], dir);
+    assert.strictEqual(use.status, 0, use.stderr);
+    const config = readConfigFile(dir);
+    assert.strictEqual(config.activeProfile, "main");
+    assert.strictEqual(config.accessToken, TOKEN_A);
+    assert.strictEqual(config.privateSessionId, SESSION_A);
+    assert.strictEqual(config.profiles.alt.accessToken, TOKEN_B);
+    assert.strictEqual(config.profiles.main.accessToken, TOKEN_A);
+  });
+
+  it("lists profiles as JSON without leaking raw tokens", () => {
+    const dir = makeConfigDir(baseFixture({
+      profiles: { main: { accessToken: TOKEN_A }, alt: { accessToken: TOKEN_B } },
+      activeProfile: "main",
+    }));
+    const result = run(["--json", "auth", "profile", "list"], dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.resource, "auth-profile-list");
+    assert.strictEqual(payload.activeProfile, "main");
+    assert.strictEqual(payload.profiles.length, 2);
+    assert.ok(!result.stdout.includes(TOKEN_A));
+    assert.ok(!result.stdout.includes(TOKEN_B));
+  });
+
+  it("rejects switching to an unknown profile", () => {
+    const dir = makeConfigDir(baseFixture());
+    const result = run(["auth", "profile", "use", "nope"], dir);
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes("Profile not found: nope"));
+  });
+
+  it("deleting the active profile keeps the active credentials", () => {
+    const dir = makeConfigDir(baseFixture());
+    assert.strictEqual(run(["auth", "profile", "save", "main"], dir).status, 0);
+    const result = run(["auth", "profile", "delete", "main"], dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    const config = readConfigFile(dir);
+    assert.strictEqual(config.activeProfile, undefined);
+    assert.strictEqual(config.profiles.main, undefined);
+    assert.strictEqual(config.accessToken, TOKEN_A);
+  });
+
+  it("does not poison saved snapshots after auth clear", () => {
+    const dir = makeConfigDir(baseFixture());
+    assert.strictEqual(run(["auth", "profile", "save", "main"], dir).status, 0);
+    assert.strictEqual(run(["auth", "clear"], dir).status, 0);
+    const cleared = readConfigFile(dir);
+    assert.strictEqual(cleared.accessToken, undefined);
+    assert.strictEqual(cleared.activeProfile, undefined);
+    assert.strictEqual(cleared.profiles.main.accessToken, TOKEN_A);
+    const use = run(["auth", "profile", "use", "main"], dir);
+    assert.strictEqual(use.status, 0, use.stderr);
+    const config = readConfigFile(dir);
+    assert.strictEqual(config.accessToken, TOKEN_A);
+    assert.strictEqual(config.profiles.main.accessToken, TOKEN_A);
+  });
+
+  it("keeps legacy single-account outputs byte-identical", () => {
+    const dir = makeConfigDir(baseFixture());
+
+    const show = run(["--json", "config", "show"], dir);
+    assert.strictEqual(show.status, 0, show.stderr);
+    const showPayload = JSON.parse(show.stdout);
+    assert.ok(!("profiles" in showPayload.config));
+    assert.ok(!("activeProfile" in showPayload.config));
+
+    const status = run(["--json", "auth", "status"], dir);
+    assert.strictEqual(status.status, 0, status.stderr);
+    const statusPayload = JSON.parse(status.stdout);
+    assert.ok(!("activeProfile" in statusPayload));
+    assert.ok(!("profileOverride" in statusPayload));
+
+    const clear = run(["--json", "auth", "clear"], dir);
+    assert.strictEqual(clear.status, 0, clear.stderr);
+    assert.deepStrictEqual(JSON.parse(clear.stdout).cleared, AUTH_CONFIG_KEYS);
+  });
+
+  it("never exposes the profiles map through config show", () => {
+    const dir = makeConfigDir(baseFixture({
+      profiles: { main: { accessToken: TOKEN_B } },
+      activeProfile: "main",
+    }));
+    const result = run(["--json", "config", "show"], dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.ok(!("profiles" in payload.config));
+    assert.ok(!result.stdout.includes(TOKEN_B));
+  });
+
+  it("runs one command as another profile with --profile", () => {
+    const dir = makeConfigDir(baseFixture({
+      profiles: { alt: { accessToken: TOKEN_B } },
+      activeProfile: "main",
+    }));
+    const result = run(["--json", "--profile", "alt", "auth", "status"], dir);
+    assert.strictEqual(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.profileOverride, "alt");
+    assert.strictEqual(payload.channels.accessToken.tokenPreview, `${TOKEN_B.slice(0, 6)}...${TOKEN_B.slice(-4)}`);
+    assert.strictEqual(payload.channels.privateSession.saved, false);
+  });
+
+  it("refuses credential writes under --profile and leaves the file untouched", () => {
+    const fixture = baseFixture({
+      profiles: { alt: { accessToken: TOKEN_B } },
+      activeProfile: "main",
+    });
+    const dir = makeConfigDir(fixture);
+    const result = run(["--profile", "alt", "auth", "set-token", "newTokenXxxxxxxxxxxx"], dir);
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes("read-only account override"));
+    assert.deepStrictEqual(readConfigFile(dir), fixture);
+  });
+
+  it("fails fast when --profile names an unknown profile", () => {
+    const dir = makeConfigDir(baseFixture());
+    const result = run(["--profile", "nope", "auth", "status"], dir);
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes("Profile not found: nope"));
+  });
+
+  it("reports auth env overrides in the profile list", () => {
+    const dir = makeConfigDir(baseFixture({
+      profiles: { main: { accessToken: TOKEN_A } },
+      activeProfile: "main",
+    }));
+    const result = run(["--json", "auth", "profile", "list"], dir, { BGM_ACCESS_TOKEN: TOKEN_B });
+    assert.strictEqual(result.status, 0, result.stderr);
+    const payload = JSON.parse(result.stdout);
+    assert.deepStrictEqual(payload.envOverrides, ["BGM_ACCESS_TOKEN"]);
+  });
+});

--- a/test/profile-integration.test.js
+++ b/test/profile-integration.test.js
@@ -96,6 +96,35 @@ describe("auth profile integration", () => {
     assert.ok(result.stderr.includes("Profile not found: nope"));
   });
 
+  it("does not treat inherited object keys as saved profiles", () => {
+    const fixture = baseFixture();
+    const dir = makeConfigDir(fixture);
+    const result = run(["auth", "profile", "use", "toString"], dir);
+    assert.strictEqual(result.status, 1);
+    assert.ok(result.stderr.includes("Profile not found: toString"));
+    assert.deepStrictEqual(readConfigFile(dir), fixture);
+
+    const save = run(["auth", "profile", "save", "constructor"], dir);
+    assert.strictEqual(save.status, 0, save.stderr);
+    assert.strictEqual(readConfigFile(dir).profiles.constructor.accessToken, TOKEN_A);
+  });
+
+  it("refuses to discard credentials that are not stored in any profile", () => {
+    const dir = makeConfigDir(baseFixture());
+    assert.strictEqual(run(["auth", "profile", "save", "main"], dir).status, 0);
+    assert.strictEqual(run(["auth", "clear"], dir).status, 0);
+    assert.strictEqual(run(["auth", "set-token", TOKEN_B], dir).status, 0);
+
+    const blocked = run(["auth", "profile", "use", "main"], dir);
+    assert.strictEqual(blocked.status, 1);
+    assert.ok(blocked.stderr.includes("would discard them"));
+    assert.strictEqual(readConfigFile(dir).accessToken, TOKEN_B);
+
+    const forced = run(["auth", "profile", "use", "main", "--force"], dir);
+    assert.strictEqual(forced.status, 0, forced.stderr);
+    assert.strictEqual(readConfigFile(dir).accessToken, TOKEN_A);
+  });
+
   it("deleting the active profile keeps the active credentials", () => {
     const dir = makeConfigDir(baseFixture());
     assert.strictEqual(run(["auth", "profile", "save", "main"], dir).status, 0);

--- a/test/profiles.test.js
+++ b/test/profiles.test.js
@@ -140,6 +140,36 @@ describe("computeProfileSwitch", () => {
     assert.strictEqual(change.set.profiles.gone.accessToken, TOKEN_A);
   });
 
+  it("treats inherited Object.prototype keys as unknown profiles", () => {
+    const raw = baseConfig({ profiles: { main: { accessToken: TOKEN_A } }, activeProfile: "main" });
+    for (const name of ["toString", "constructor", "valueOf", "hasOwnProperty"]) {
+      assert.throws(() => computeProfileSwitch(raw, name), /Profile not found/);
+      assert.throws(() => computeProfileDelete(raw, name), /Profile not found/);
+      const save = computeProfileSave(raw, name);
+      assert.strictEqual(save.set.profiles[name].accessToken, TOKEN_A);
+    }
+  });
+
+  it("rejects switching to a profile with no saved credentials", () => {
+    const raw = baseConfig({ profiles: { empty: { tokenType: "Bearer" } }, activeProfile: "main" });
+    assert.throws(() => computeProfileSwitch(raw, "empty"), /no saved credentials/);
+  });
+
+  it("refuses to discard credentials that no profile holds", () => {
+    const raw = baseConfig({ profiles: { alt: { accessToken: TOKEN_B } } });
+    assert.throws(() => computeProfileSwitch(raw, "alt"), /would discard them/);
+    const forced = computeProfileSwitch(raw, "alt", { force: true });
+    assert.strictEqual(forced.set.accessToken, TOKEN_B);
+    assert.strictEqual(forced.syncedPrevious, false);
+  });
+
+  it("allows switching without an active profile when the credentials are already saved", () => {
+    const raw = baseConfig({ profiles: { main: { accessToken: TOKEN_A }, alt: { accessToken: TOKEN_B } } });
+    const change = computeProfileSwitch(raw, "alt");
+    assert.strictEqual(change.set.accessToken, TOKEN_B);
+    assert.strictEqual(change.set.profiles.main.accessToken, TOKEN_A);
+  });
+
   it("rejects unknown targets and lists saved names", () => {
     const raw = baseConfig({ profiles: { main: { accessToken: TOKEN_A } } });
     assert.throws(() => computeProfileSwitch(raw, "nope"), /Profile not found: nope. Saved profiles: main/);

--- a/test/profiles.test.js
+++ b/test/profiles.test.js
@@ -1,0 +1,237 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  buildProfileListPayload,
+  computeProfileDelete,
+  computeProfileSave,
+  computeProfileSwitch,
+  listAuthEnvOverrides,
+  pickAuthSnapshot,
+  snapshotHasCredentials,
+  validateProfileName,
+} from "../src/utils/profiles.js";
+import { AUTH_CONFIG_KEYS } from "../src/core/config.js";
+
+const TOKEN_A = "tokenAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+const TOKEN_B = "tokenBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+const SESSION_A = "sessionAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+function baseConfig(extra = {}) {
+  return {
+    accessToken: TOKEN_A,
+    tokenType: "Bearer",
+    proxy: "http://127.0.0.1:7890",
+    timezone: "Asia/Shanghai",
+    ...extra,
+  };
+}
+
+describe("validateProfileName", () => {
+  it("accepts simple and punctuated names", () => {
+    assert.strictEqual(validateProfileName("main"), "main");
+    assert.strictEqual(validateProfileName("a.b-c_1"), "a.b-c_1");
+    assert.strictEqual(validateProfileName(" alt "), "alt");
+  });
+
+  it("rejects invalid names", () => {
+    for (const name of ["", "  ", "__proto__", "-x", ".hidden", "a".repeat(33), "with space", "中文", undefined, null]) {
+      assert.throws(() => validateProfileName(name), /Invalid profile name/);
+    }
+  });
+});
+
+describe("pickAuthSnapshot", () => {
+  it("picks only auth keys that exist", () => {
+    const snapshot = pickAuthSnapshot(baseConfig({ privateSessionId: SESSION_A }));
+    assert.deepStrictEqual(Object.keys(snapshot).sort(), ["accessToken", "privateSessionId", "tokenType"]);
+    assert.strictEqual(snapshot.proxy, undefined);
+    assert.strictEqual(snapshot.timezone, undefined);
+  });
+
+  it("returns empty object for empty or non-object input", () => {
+    assert.deepStrictEqual(pickAuthSnapshot({}), {});
+    assert.deepStrictEqual(pickAuthSnapshot(null), {});
+    assert.deepStrictEqual(pickAuthSnapshot("x"), {});
+  });
+});
+
+describe("snapshotHasCredentials", () => {
+  it("requires an access token or private session", () => {
+    assert.strictEqual(snapshotHasCredentials({ accessToken: TOKEN_A }), true);
+    assert.strictEqual(snapshotHasCredentials({ privateSessionId: SESSION_A }), true);
+    assert.strictEqual(snapshotHasCredentials({ tokenType: "Bearer", refreshToken: null }), false);
+    assert.strictEqual(snapshotHasCredentials({}), false);
+  });
+});
+
+describe("computeProfileSave", () => {
+  it("creates a new profile and marks it active", () => {
+    const change = computeProfileSave(baseConfig(), "main");
+    assert.strictEqual(change.set.activeProfile, "main");
+    assert.deepStrictEqual(change.set.profiles.main, { accessToken: TOKEN_A, tokenType: "Bearer" });
+    assert.deepStrictEqual(change.remove, []);
+  });
+
+  it("rejects saving when no credentials are stored", () => {
+    assert.throws(() => computeProfileSave({ proxy: "http://x" }, "main"), /No saved auth credentials/);
+  });
+
+  it("requires --force to overwrite a non-active profile", () => {
+    const raw = baseConfig({ profiles: { alt: { accessToken: TOKEN_B } }, activeProfile: "main" });
+    assert.throws(() => computeProfileSave(raw, "alt"), /Pass --force/);
+    const forced = computeProfileSave(raw, "alt", { force: true });
+    assert.strictEqual(forced.set.profiles.alt.accessToken, TOKEN_A);
+  });
+
+  it("always allows re-saving the active profile", () => {
+    const raw = baseConfig({ profiles: { main: { accessToken: TOKEN_B } }, activeProfile: "main" });
+    const change = computeProfileSave(raw, "main");
+    assert.strictEqual(change.set.profiles.main.accessToken, TOKEN_A);
+  });
+
+  it("keeps other profile entries", () => {
+    const raw = baseConfig({ profiles: { alt: { accessToken: TOKEN_B } } });
+    const change = computeProfileSave(raw, "main");
+    assert.strictEqual(change.set.profiles.alt.accessToken, TOKEN_B);
+  });
+});
+
+describe("computeProfileSwitch", () => {
+  it("loads the target snapshot and removes keys it lacks", () => {
+    const raw = baseConfig({
+      privateSessionId: SESSION_A,
+      profiles: { alt: { accessToken: TOKEN_B, tokenType: "Bearer" } },
+      activeProfile: "main",
+    });
+    const change = computeProfileSwitch(raw, "alt");
+    assert.strictEqual(change.set.accessToken, TOKEN_B);
+    assert.strictEqual(change.set.activeProfile, "alt");
+    assert.ok(change.remove.includes("privateSessionId"));
+    assert.ok(!change.remove.includes("accessToken"));
+  });
+
+  it("syncs the current credentials back into the previous profile", () => {
+    const raw = baseConfig({
+      profiles: { main: { accessToken: TOKEN_B }, alt: { accessToken: TOKEN_B } },
+      activeProfile: "main",
+    });
+    const change = computeProfileSwitch(raw, "alt");
+    assert.strictEqual(change.syncedPrevious, true);
+    assert.strictEqual(change.previousProfile, "main");
+    assert.strictEqual(change.set.profiles.main.accessToken, TOKEN_A);
+  });
+
+  it("does not overwrite the previous profile with an empty snapshot", () => {
+    const raw = {
+      profiles: { main: { accessToken: TOKEN_A }, alt: { accessToken: TOKEN_B } },
+      activeProfile: "main",
+    };
+    const change = computeProfileSwitch(raw, "alt");
+    assert.strictEqual(change.syncedPrevious, false);
+    assert.strictEqual(change.set.profiles.main.accessToken, TOKEN_A);
+  });
+
+  it("recreates a dangling active profile entry instead of losing credentials", () => {
+    const raw = baseConfig({
+      profiles: { alt: { accessToken: TOKEN_B } },
+      activeProfile: "gone",
+    });
+    const change = computeProfileSwitch(raw, "alt");
+    assert.strictEqual(change.set.profiles.gone.accessToken, TOKEN_A);
+  });
+
+  it("rejects unknown targets and lists saved names", () => {
+    const raw = baseConfig({ profiles: { main: { accessToken: TOKEN_A } } });
+    assert.throws(() => computeProfileSwitch(raw, "nope"), /Profile not found: nope. Saved profiles: main/);
+    assert.throws(() => computeProfileSwitch(baseConfig(), "nope"), /Saved profiles: \(none\)/);
+  });
+});
+
+describe("computeProfileDelete", () => {
+  it("deletes a non-active profile and keeps the pointer", () => {
+    const raw = baseConfig({
+      profiles: { main: { accessToken: TOKEN_A }, alt: { accessToken: TOKEN_B } },
+      activeProfile: "main",
+    });
+    const change = computeProfileDelete(raw, "alt");
+    assert.strictEqual(change.wasActive, false);
+    assert.deepStrictEqual(change.remove, []);
+    assert.strictEqual(change.set.profiles.alt, undefined);
+    assert.strictEqual(change.set.profiles.main.accessToken, TOKEN_A);
+  });
+
+  it("deleting the active profile removes the pointer only", () => {
+    const raw = baseConfig({ profiles: { main: { accessToken: TOKEN_A } }, activeProfile: "main" });
+    const change = computeProfileDelete(raw, "main");
+    assert.strictEqual(change.wasActive, true);
+    assert.deepStrictEqual(change.remove, ["activeProfile"]);
+    assert.deepStrictEqual(change.set.profiles, {});
+    assert.strictEqual(change.set.accessToken, undefined);
+  });
+
+  it("rejects unknown profiles", () => {
+    assert.throws(() => computeProfileDelete(baseConfig(), "nope"), /Profile not found/);
+  });
+});
+
+describe("buildProfileListPayload", () => {
+  it("marks the active profile and masks credentials", () => {
+    const raw = baseConfig({
+      profiles: {
+        main: { accessToken: TOKEN_A, privateSessionId: SESSION_A, privateSessionUpdatedAt: "2026-08-01T00:00:00.000Z" },
+        alt: { accessToken: TOKEN_B },
+      },
+      activeProfile: "main",
+    });
+    const payload = buildProfileListPayload(raw, { configFile: "/tmp/config.json" });
+    assert.strictEqual(payload.resource, "auth-profile-list");
+    assert.strictEqual(payload.activeProfile, "main");
+    assert.strictEqual(payload.activeProfileMissing, false);
+    const main = payload.profiles.find((profile) => profile.name === "main");
+    assert.strictEqual(main.active, true);
+    assert.strictEqual(main.accessTokenSaved, true);
+    assert.strictEqual(main.privateSessionSaved, true);
+    const serialized = JSON.stringify(payload);
+    assert.ok(!serialized.includes(TOKEN_A));
+    assert.ok(!serialized.includes(TOKEN_B));
+    assert.ok(!serialized.includes(SESSION_A));
+  });
+
+  it("handles empty and malformed profile entries", () => {
+    const payload = buildProfileListPayload({ profiles: { bad: "not-an-object" } }, {});
+    assert.deepStrictEqual(payload.profiles, []);
+    const empty = buildProfileListPayload({}, {});
+    assert.strictEqual(empty.activeProfile, null);
+    assert.deepStrictEqual(empty.profiles, []);
+  });
+
+  it("flags a dangling active profile pointer", () => {
+    const payload = buildProfileListPayload({ activeProfile: "gone", profiles: {} }, {});
+    assert.strictEqual(payload.activeProfileMissing, true);
+  });
+});
+
+describe("listAuthEnvOverrides", () => {
+  it("returns only non-empty auth env names", () => {
+    assert.deepStrictEqual(
+      listAuthEnvOverrides({ BGM_ACCESS_TOKEN: "x", BGM_REFRESH_TOKEN: " ", BGM_PRIVATE_SESSION_ID: "" , PATH: "/bin" }),
+      ["BGM_ACCESS_TOKEN"],
+    );
+    assert.deepStrictEqual(listAuthEnvOverrides({}), []);
+  });
+});
+
+describe("AUTH_CONFIG_KEYS", () => {
+  it("keeps the full credential field set", () => {
+    assert.deepStrictEqual(AUTH_CONFIG_KEYS, [
+      "accessToken",
+      "refreshToken",
+      "tokenType",
+      "privateSessionId",
+      "privateSessionUpdatedAt",
+      "clientId",
+      "clientSecret",
+      "redirectUri",
+    ]);
+  });
+});

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -1,4 +1,7 @@
 import { spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { describe, it } from "node:test";
 import assert from "node:assert";
 import { formatDisplayResult } from "../src/core/output.js";
@@ -6,6 +9,7 @@ import { resolveProxyUrl } from "../src/core/proxy.js";
 
 const CLI = "node";
 const CLI_ARGS = ["src/cli.js"];
+const ISOLATED_CONFIG_DIR = mkdtempSync(path.join(os.tmpdir(), "bgm-proxy-test-"));
 
 function run(args, env) {
   return spawnSync(CLI, [...CLI_ARGS, ...args], {
@@ -22,6 +26,7 @@ function buildEnv(extra = {}) {
   delete env.https_proxy;
   delete env.HTTP_PROXY;
   delete env.http_proxy;
+  env.BGM_CONFIG_DIR = ISOLATED_CONFIG_DIR;
   return { ...env, ...extra };
 }
 

--- a/test/smoke.test.js
+++ b/test/smoke.test.js
@@ -52,4 +52,11 @@ describe("smoke", () => {
       assert.ok(result.stdout.length > 0, `${group} help should produce output`);
     });
   }
+
+  it("should mention profile commands in auth help", () => {
+    const result = run(["auth", "--help"]);
+    assert.strictEqual(result.status, 0);
+    assert.ok(result.stdout.includes("auth profile"), "auth help should mention profile commands");
+    assert.ok(result.stdout.includes("--profile"), "auth help should mention the --profile override");
+  });
 });


### PR DESCRIPTION
## Summary

- Add `bgm auth profile <list|save|use|delete>` for named credential snapshots with copy-on-switch semantics: the flat top-level config keys keep meaning "the active account"; `use` syncs them back into the previous profile, then loads the target profile in a single atomic write (an empty snapshot is never synced back, so `auth clear` cannot poison a saved profile).
- Add a global `--profile <name>` flag to run one command as another saved account without switching. The override is strictly read-only: `auth login`, `auth set-token`, `auth clear`, profile writes, `--init`, `tui`, and `config set/unset` on credential keys all refuse to run with it.
- `getConfig()` strips the `profiles` map from its result, so `config show` (including `--json`) and the request layer never see other accounts' credentials; `auth profile list` exposes masked previews only. Auth env variables (`BGM_ACCESS_TOKEN`, ...) still take precedence and produce a warning line.
- Add `BGM_CONFIG_DIR` (config directory override, read at process start) for test isolation, and use it to make the previously environment-dependent proxy integration tests hermetic.
- Docs: command tables and config model in `docs/`, multi-account quick-start in all three READMEs, operate-skill references.

## Backwards compatibility

Existing single-account behavior is unchanged: all current credential read/write paths still operate on the flat top-level keys, and users without profiles get byte-identical `auth status` / `auth clear` / `config show` output (locked by integration tests). `profiles` / `activeProfile` are deliberately not accepted by `config set`, matching the existing `privateSessionId` precedent.

## Test plan

- `npm test`: 115/115 passing (40 new tests: pure-function unit tests for the profile logic, isolated end-to-end integration tests via `BGM_CONFIG_DIR`, output formatter tests, smoke help assertions)
- Manual smoke on a real config: `auth profile save/list/use`, `--profile <name> auth status`, `--profile <name> user me` against the live API, and write-guard rejection under `--profile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)