### PR TITLE
fix: polish the --profile override rough edges

### DIFF
--- a/docs/implementation.zh-CN.md
+++ b/docs/implementation.zh-CN.md
@@ -59,7 +59,8 @@
 - `bgm auth profile use <name>` 采用切换时拷贝（copy-on-switch）：先把顶层凭据回存到原活动 profile（当前凭据为空时跳过回存，防止空快照覆盖），再把目标 profile 的凭据整组写到顶层，整个变更单次原子写盘。
 - `getConfig()` 的返回值会剔除 `profiles`，因此 `config show`（含 `--json`）与请求层永远接触不到其他账户的完整凭据。
 - `bgm --profile <name> <command>` 是只读覆盖：仅在本次进程内用该 profile 的凭据整组替换生效值，不写盘、不改 `activeProfile`；会写入凭据的命令在此模式下拒绝执行。
-- 环境变量优先级仍然最高：设置了 `BGM_ACCESS_TOKEN` 等变量时，profile 切换"看起来不生效"，相关命令输出会列出正在覆盖的变量名。
+- 环境变量优先级仍然最高：设置了 `BGM_ACCESS_TOKEN` 等变量时，profile 切换"看起来不生效"，相关命令输出会列出正在覆盖的变量名；使用 `--profile` 时会额外在 stderr 打一行 warning（不污染 `--json` 的 stdout），`auth status` 的载荷也会带上 `envOverrides`。
+- `--profile` 的解析发生在 `--version` / `--help` 分支之后，因此即使 profile 名不存在，帮助与版本信息仍然可以正常打开。
 - `profiles` 与 `activeProfile` 不在 `config set` 白名单内，只能通过 `bgm auth profile` 子命令操作。
 
 代理配置是一个例外：`config.proxy` 保持最高优先级，之后才读取代理环境变量。代理解析顺序为：

--- a/src/cli.js
+++ b/src/cli.js
@@ -133,11 +133,6 @@ async function main(argv) {
     rawArgs: parsed.args,
   };
 
-  if (parsed.profile !== undefined) {
-    setProfileOverride(parsed.profile);
-    getConfig();
-  }
-
   try {
     installProxyFromConfig(getConfig());
   } catch (error) {
@@ -149,6 +144,17 @@ async function main(argv) {
     return;
   }
 
+  if (hasHelpFlag(parsed.args)) {
+    printUsage(resolveHelpTarget(parsed.args));
+    return;
+  }
+
+  if (parsed.profile !== undefined) {
+    setProfileOverride(parsed.profile);
+    getConfig();
+    warnAuthEnvOverrides();
+  }
+
   if (parsed.init) {
     ensureNoProfileOverride("bgm --init");
     await runInitWizard(context);
@@ -157,11 +163,6 @@ async function main(argv) {
 
   if (parsed.args.length === 0) {
     printUsage();
-    return;
-  }
-
-  if (hasHelpFlag(parsed.args)) {
-    printUsage(resolveHelpTarget(parsed.args));
     return;
   }
 
@@ -875,6 +876,15 @@ async function runAuthProfileCommand(options, context) {
   }
 }
 
+function warnAuthEnvOverrides() {
+  const envOverrides = listAuthEnvOverrides();
+  if (envOverrides.length > 0) {
+    process.stderr.write(
+      `Warning: environment variables override the --profile credentials: ${envOverrides.join(", ")}\n`,
+    );
+  }
+}
+
 function ensureNoProfileOverride(actionLabel) {
   if (getProfileOverride()) {
     throw new CommandError(
@@ -919,12 +929,14 @@ function buildAuthStatusPayload(config) {
     ? config.activeProfile.trim()
     : null;
   const profileOverride = getProfileOverride();
+  const envOverrides = profileOverride ? listAuthEnvOverrides() : [];
 
   return {
     resource: "auth-status",
     configFile: getConfigFilePath(),
     ...(activeProfile ? { activeProfile } : {}),
     ...(profileOverride ? { profileOverride } : {}),
+    ...(envOverrides.length > 0 ? { envOverrides } : {}),
     policy: "p1 requests use the private session cookie when saved; Access Token is not sent together with it.",
     channels: {
       accessToken: {

--- a/src/core/output.js
+++ b/src/core/output.js
@@ -809,6 +809,9 @@ function formatAuthStatus(payload) {
     `  Config file: ${payload.configFile ?? "-"}`,
     payload.activeProfile ? `  Active profile: ${payload.activeProfile}` : null,
     payload.profileOverride ? `  Profile override (--profile): ${payload.profileOverride}` : null,
+    Array.isArray(payload.envOverrides) && payload.envOverrides.length > 0
+      ? `  Warning: environment variables override saved credentials: ${payload.envOverrides.join(", ")}`
+      : null,
     payload.policy ? `  Policy: ${payload.policy}` : null,
     "",
     "Access Token channel",

--- a/test/profile-integration.test.js
+++ b/test/profile-integration.test.js
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert";
 import { AUTH_CONFIG_KEYS } from "../src/core/config.js";
 
@@ -12,8 +12,17 @@ const TOKEN_A = "fixtureTokenAxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 const TOKEN_B = "fixtureTokenBxxxxxxxxxxxxxxxxxxxxxxxxxxx";
 const SESSION_A = "fixtureSessionAxxxxxxxxxxxxxxxxxxxxxxxxx";
 
+const createdConfigDirs = [];
+
+after(() => {
+  for (const dir of createdConfigDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 function makeConfigDir(fixture) {
   const dir = mkdtempSync(path.join(os.tmpdir(), "bgm-profile-test-"));
+  createdConfigDirs.push(dir);
   writeFileSync(path.join(dir, "config.json"), `${JSON.stringify(fixture, null, 2)}\n`, "utf8");
   return dir;
 }
@@ -213,6 +222,31 @@ describe("auth profile integration", () => {
     const result = run(["--profile", "nope", "auth", "status"], dir);
     assert.strictEqual(result.status, 1);
     assert.ok(result.stderr.includes("Profile not found: nope"));
+  });
+
+  it("still prints help and version when --profile is unknown", () => {
+    const dir = makeConfigDir(baseFixture());
+    for (const args of [["--profile", "nope", "auth", "--help"], ["--profile", "nope", "--version"]]) {
+      const result = run(args, dir);
+      assert.strictEqual(result.status, 0, result.stderr);
+      assert.ok(result.stdout.length > 0);
+    }
+  });
+
+  it("warns when auth env variables override the --profile credentials", () => {
+    const dir = makeConfigDir(baseFixture({
+      profiles: { alt: { accessToken: TOKEN_B } },
+      activeProfile: "main",
+    }));
+    const result = run(["--json", "--profile", "alt", "auth", "status"], dir, { BGM_ACCESS_TOKEN: TOKEN_A });
+    assert.strictEqual(result.status, 0, result.stderr);
+    assert.ok(result.stderr.includes("BGM_ACCESS_TOKEN"));
+    assert.deepStrictEqual(JSON.parse(result.stdout).envOverrides, ["BGM_ACCESS_TOKEN"]);
+
+    const quiet = run(["--json", "--profile", "alt", "auth", "status"], dir);
+    assert.strictEqual(quiet.status, 0, quiet.stderr);
+    assert.strictEqual(quiet.stderr, "");
+    assert.ok(!("envOverrides" in JSON.parse(quiet.stdout)));
   });
 
   it("reports auth env overrides in the profile list", () => {

--- a/test/proxy.test.js
+++ b/test/proxy.test.js
@@ -1,8 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { describe, it } from "node:test";
+import { after, describe, it } from "node:test";
 import assert from "node:assert";
 import { formatDisplayResult } from "../src/core/output.js";
 import { resolveProxyUrl } from "../src/core/proxy.js";
@@ -10,6 +10,10 @@ import { resolveProxyUrl } from "../src/core/proxy.js";
 const CLI = "node";
 const CLI_ARGS = ["src/cli.js"];
 const ISOLATED_CONFIG_DIR = mkdtempSync(path.join(os.tmpdir(), "bgm-proxy-test-"));
+
+after(() => {
+  rmSync(ISOLATED_CONFIG_DIR, { recursive: true, force: true });
+});
 
 function run(args, env) {
   return spawnSync(CLI, [...CLI_ARGS, ...args], {


### PR DESCRIPTION
Follow-up to #4, cleaning up the three minor items left open in that review. No behavior change for anyone not using `--profile`.

## Changes

**`--profile` no longer breaks `--help` / `--version`.** The override was resolved at the very top of `main()`, so `bgm --profile typo --help` exited 1 with `Profile not found` instead of printing help. Resolution now happens after the `--version` and help branches — still before `--init`, `tui`, and every group dispatch, so `ensureNoProfileOverride()` sees the override exactly as before. `bgm --init` keeps working because the empty-args check stays below it.

**Env overrides are now visible during a `--profile` run.** `BGM_ACCESS_TOKEN` and friends outrank any profile, which makes a switch look like it silently did nothing. `auth profile list` already warned about this; a `--profile` run did not. It now writes one warning line to stderr (so `--json` stdout stays clean) and `auth status` carries the same list as `envOverrides`. Both are omitted when no override is in play, so existing output is byte-identical.

**Integration tests clean up after themselves.** `test/proxy.test.js` and `test/profile-integration.test.js` created one `mkdtemp` directory per test and never removed them — a full run left 20+ behind in the system temp dir. Both now remove them in an `after()` hook.

## Test plan

- `npm test`: 123/123 passing (2 new integration tests: help/version under an unknown profile, and the env-override warning on both stderr and the JSON payload)
- Verified manually that a test run now leaves zero `bgm-*-test-*` directories behind, and that `bgm`, `bgm --help`, and `bgm --version` are unchanged without `--profile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)