### PR TITLE
feat: resolve pasted Bangumi URLs into CLI commands

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -103,6 +103,24 @@ bgm trending subjects --type anime --limit 5
 bgm --json user me
 ```
 
+### Paste A Link
+
+Hand a Bangumi web link straight to `bgm` and it resolves to the matching command:
+
+```bash
+bgm "https://bangumi.tv/group/topic/469977#post_4029724"   # that single reply -> bgm group post 4029724
+bgm url https://bgm.tv/subject/253/characters              # -> bgm subject characters 253
+bgm --url https://bgm.tv/anime/list/sai/collect --dry-run  # resolve only, no request
+```
+
+- Three equivalent forms: `bgm <url>`, `bgm url <url>`, `bgm --url <url>` (`-url` also works).
+- Hosts: `bgm.tv`, `bangumi.tv`, `chii.in`, `next.bgm.tv`, `api.bgm.tv`; the `https://` and `www.` prefixes are optional.
+- Resolution is read-only, so a link never triggers a write. `--dry-run` prints the resolution and stops.
+- A `#post_<id>` anchor resolves to that single reply; `?page=n` becomes `--offset`.
+- Extra flags are forwarded to the resolved command, and `--json` output carries a `resolvedFrom` field.
+- Quote links containing `#` so the shell does not truncate them.
+- Run `bgm url --help` for the full list of supported link shapes.
+
 ## Documentation Index
 
 - This project also ships installable Skills for AI or agent workflows around `bgm-cli`.

--- a/README.md
+++ b/README.md
@@ -110,6 +110,24 @@ bgm status --site bgm.tv
 bgm --json user me
 ```
 
+### 粘贴链接直接查询
+
+把 Bangumi 网页链接直接交给 `bgm`，它会解析成对应命令并输出同样的结果：
+
+```bash
+bgm "https://bangumi.tv/group/topic/469977#post_4029724"   # 定位到该楼 -> bgm group post 4029724
+bgm url https://bgm.tv/subject/253/characters              # -> bgm subject characters 253
+bgm --url https://bgm.tv/anime/list/sai/collect --dry-run  # 只看解析结果，不发请求
+```
+
+- 三种写法等价：`bgm <url>`、`bgm url <url>`、`bgm --url <url>`（`-url` 亦可）。
+- 支持 `bgm.tv`、`bangumi.tv`、`chii.in`、`next.bgm.tv`、`api.bgm.tv`，可省略 `https://` 与 `www.`。
+- 解析是只读的，链接永远不会触发写操作；`--dry-run` 只打印解析结果。
+- `#post_<id>` 锚点会精确定位到该楼回复；`?page=n` 会换算成 `--offset`。
+- 多余的参数会透传给解析出的命令，`--json` 输出会附带 `resolvedFrom` 溯源字段。
+- 链接含 `#` 时请加引号，否则会被 shell 截断。
+- 完整支持列表见 `bgm url --help`。
+
 ## 文档索引
 
 - 本项目同时提供可安装的 Skills，适合让 AI / Agent 直接安装并操作 `bgm-cli`。

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -103,6 +103,24 @@ bgm trending subjects --type anime --limit 5
 bgm --json user me
 ```
 
+### 貼上連結直接查詢
+
+把 Bangumi 網頁連結直接交給 `bgm`，它會解析成對應命令並輸出同樣的結果：
+
+```bash
+bgm "https://bangumi.tv/group/topic/469977#post_4029724"   # 定位到該樓 -> bgm group post 4029724
+bgm url https://bgm.tv/subject/253/characters              # -> bgm subject characters 253
+bgm --url https://bgm.tv/anime/list/sai/collect --dry-run  # 只看解析結果，不發請求
+```
+
+- 三種寫法等價：`bgm <url>`、`bgm url <url>`、`bgm --url <url>`（`-url` 亦可）。
+- 支援 `bgm.tv`、`bangumi.tv`、`chii.in`、`next.bgm.tv`、`api.bgm.tv`，可省略 `https://` 與 `www.`。
+- 解析是唯讀的，連結永遠不會觸發寫入操作；`--dry-run` 只印出解析結果。
+- `#post_<id>` 錨點會精確定位到該樓回覆；`?page=n` 會換算成 `--offset`。
+- 多餘的參數會透傳給解析出的命令，`--json` 輸出會附帶 `resolvedFrom` 溯源欄位。
+- 連結含 `#` 時請加引號，否則會被 shell 截斷。
+- 完整支援列表見 `bgm url --help`。
+
 ## 文件索引
 
 - 本專案同時提供可安裝的 Skills，適合讓 AI / Agent 直接安裝並操作 `bgm-cli`。

--- a/docs/features.zh-CN.md
+++ b/docs/features.zh-CN.md
@@ -19,6 +19,7 @@
 - 读取热门条目和热门条目讨论
 - 通过 SearchEncore 搜索条目、用户、小组、话题、回复、目录和日志
 - 读取社区维护的 Bangumi 可用性状态源
+- 粘贴 Bangumi 网页链接，自动解析成对应命令并输出
 - 在普通终端输出和 `--json` 机器输出之间切换
 - 通过 HTTP/HTTPS 代理访问 Bangumi API
 
@@ -40,6 +41,75 @@
 | `bgm --json <command...>` | 以 JSON 输出任意支持命令的结果 |
 | `bgm --init` | 启动交互式初始化向导 |
 | `bgm tui` | 打开交互式 TUI |
+
+### URL 解析
+
+把 Bangumi 网页链接直接交给 CLI，解析成对应命令后执行，输出与手敲那条命令完全一致。
+
+| 命令 | 说明 |
+| --- | --- |
+| `bgm <bangumi_url> [--dry-run]` | 裸链接形式，直接解析并执行 |
+| `bgm url <bangumi_url> [--dry-run]` | 显式子命令形式 |
+| `bgm --url <bangumi_url> [--dry-run]` | 全局 flag 形式，`-url` 为兼容别名 |
+
+支持的域名：`bgm.tv`、`bangumi.tv`、`chii.in`、`next.bgm.tv`、`api.bgm.tv`，可省略 `https://` 与 `www.` 前缀。
+
+| 链接形态 | 解析结果 |
+| --- | --- |
+| `/subject/<id>` | `subject get <id>` |
+| `/subject/<id>/comments` | `subject comments <id>` |
+| `/subject/<id>/reviews` | `subject reviews <id>` |
+| `/subject/<id>/board` | `subject topics <id>` |
+| `/subject/<id>/characters` | `subject characters <id>` |
+| `/subject/<id>/persons` | `subject staff <id>` |
+| `/subject/<id>/collections` | `subject collects <id>` |
+| `/subject/<id>/index` | `subject indexes <id>` |
+| `/subject/<id>/ep` | `episode list <id>` |
+| `/subject/topic/<id>` | `subject topic <id>` |
+| `/subject/topic/<id>#post_<pid>` | `subject post <pid>` |
+| `/group/topic/<id>` | `group topic <id>` |
+| `/group/topic/<id>#post_<pid>` | `group post <pid>` |
+| `/group/<name>` | `group get <name>` |
+| `/group/<name>/forum` | `group topics <name>` |
+| `/group/<name>/members` | `group members <name>` |
+| `/group/category/all` | `group list --mode all` |
+| `/ep/<id>` | `episode get <id>` |
+| `/character/<id>` | `character get <id>` |
+| `/character/<id>/collections\|indices\|album` | `character collects\|indexes\|photos <id>` |
+| `/person/<id>` | `person get <id>` |
+| `/person/<id>/collections\|indices\|album\|works\|collabs` | `person collects\|indexes\|photos\|works\|relations <id>` |
+| `/blog/<id>` | `blog get <id>` |
+| `/blog/<id>/photos` | `blog photos <id>` |
+| `/index/<id>` | `index get <id>` |
+| `/index/<id>/comments` | `index comments <id>` |
+| `/user/<name>` | `user get <name>` |
+| `/user/<name>/timeline` | `timeline user <name>` |
+| `/user/<name>/blog` | `blog list --user <name>` |
+| `/user/<name>/index` | `index user <name>` |
+| `/user/<name>/friends\|followers` | `user friends\|followers <name>` |
+| `/user/<name>/groups` | `group user <name>` |
+| `/user/<name>/mono/character\|person` | `collection characters\|persons --user <name>` |
+| `/<type>/list/<name>[/<status>]` | `collection list --user <name> --type <type> [--status <status>]` |
+| `/<type>/browser` | `subject list --type <type>` |
+| `/<type>/tag/<tag>` | `subject list --type <type> --tag <tag>` |
+| `/subject_search/<keyword>?cat=n` | `subject search <keyword> [--type ...]` |
+| `/mono_search/<keyword>?cat=1\|2` | `character\|person search <keyword>` |
+| `/calendar` | `calendar all` |
+| `/timeline` | `timeline list` |
+| `/notify` | `notify list` |
+| `api.bgm.tv/v0/...` | 对应的 `subject` / `episode` / `character` / `person` / `user` / `collection` / `index` 命令 |
+
+其中 `<type>` 为 `anime\|book\|music\|game\|real`，站点收藏状态段 `wish\|collect\|do\|on_hold\|dropped` 会归一化成 CLI 的 `wish\|collect\|doing\|on_hold\|dropped`。
+
+行为约定：
+
+- 解析全程离线且只读，链接不会触发任何写操作。
+- `--dry-run` 只打印解析结果（域名、路径、目标命令），不发请求。
+- `?page=n`（n > 1）会换算成 `--offset`，同时锁定 `--limit 20` 以保证偏移量有意义；`?limit=` / `?offset=` 优先于 `page`；无法识别的 query 静默忽略。
+- 命令行上多余的参数会按原顺序透传给解析出的命令。
+- `--json` 输出等于目标命令的原始 payload 加一个 `resolvedFrom` 字段（`url` / `site` / `command` / `args`）；终端输出与目标命令完全一致，不加任何额外内容。
+- 域名在白名单内但路径无法解析时直接报错，并在能推导时给出 `Did you mean: bgm ...` 建议；`/rakuen/topic/group|subject/<id>` 属于此类，会提示对应命令而不是自动执行。
+- 链接含 `#` 时需要加引号，否则会被 shell 当作注释截断。
 
 ### Setup
 

--- a/skills/bgm-cli-operate/SKILL.md
+++ b/skills/bgm-cli-operate/SKILL.md
@@ -105,7 +105,26 @@ bgm auth session-status
 - keep search result sets small when the user does not know an exact ID
 - remember that `bgm --help` is now only a compact overview; use `bgm <group> --help` for full command details such as `bgm episode --help` or `bgm blog --help`
 
-### 5. Verify important writes
+### 5. Resolve pasted Bangumi links with the URL entry point
+
+When the user supplies a Bangumi web link instead of an ID, hand the link to the CLI rather than parsing it by hand.
+
+```bash
+bgm --json --url "https://bangumi.tv/group/topic/469977#post_4029724" --dry-run
+bgm --json "https://bangumi.tv/group/topic/469977#post_4029724"
+```
+
+- Three equivalent forms: `bgm <url>`, `bgm url <url>`, `bgm --url <url>` (`-url` is an alias).
+- Hosts: `bgm.tv`, `bangumi.tv`, `chii.in`, `next.bgm.tv`, `api.bgm.tv`; `https://` and `www.` are optional.
+- Run `--dry-run` first when the mapping matters; it prints the resolved command offline and makes no request.
+- Resolution is read-only. A link never triggers a write, so keep using the explicit write commands.
+- `#post_<id>` resolves to that single reply, not the whole topic.
+- `--json` returns the target command's payload plus a `resolvedFrom` field (`url`, `site`, `command`, `args`), so downstream parsing is unchanged.
+- Always quote links containing `#`, otherwise the shell truncates them.
+- Unsupported paths fail with a `Did you mean: bgm ...` suggestion; follow the suggestion instead of retrying the link.
+- Run `bgm url --help` for the full list of supported link shapes.
+
+### 6. Verify important writes
 
 For collection, episode-progress, notification, subject/group topic, character/person/blog/index comment, index, or timeline writes, read back the final state when the result matters.
 
@@ -190,6 +209,8 @@ bgm --json timeline user sai --limit 10
 bgm --json timeline replies 123456
 bgm --json calendar
 bgm --json calendar all
+bgm --json url https://bgm.tv/subject/253/characters
+bgm --json --url https://bgm.tv/anime/list/sai/collect --dry-run
 ```
 
 ### Common writes
@@ -231,5 +252,6 @@ When reporting back to a user or another agent, always say:
 - whether auth was already present or had to be set up
 - which commands were run
 - whether results came from JSON output or human-readable output
+- when a pasted link was resolved, which command it resolved to (from `--dry-run` or the `resolvedFrom` field)
 - for episode operations, whether the parent subject was already collected and whether NSFW auth restrictions affected the task
 - what could not be completed because of missing auth, install failure, or unsupported CLI scope

--- a/skills/bgm-cli-operate/references/commands.md
+++ b/skills/bgm-cli-operate/references/commands.md
@@ -31,6 +31,46 @@ bgm --profile <name> <command> ...
 
 Use `bgm --help` for the compact overview only. For detailed command discovery, prefer `bgm <group> --help`.
 
+## URL Resolution
+
+```bash
+bgm --json <bangumi_url>
+bgm --json url <bangumi_url>
+bgm --json --url <bangumi_url>
+bgm --json --url <bangumi_url> --dry-run
+```
+
+Turns a pasted Bangumi link into the matching command and runs it. Hosts: `bgm.tv`, `bangumi.tv`, `chii.in`, `next.bgm.tv`, `api.bgm.tv`; `https://` and `www.` prefixes are optional. `-url` is an alias for `--url`.
+
+| Link | Resolves to |
+| --- | --- |
+| `/subject/<id>` | `subject get <id>` |
+| `/subject/<id>/comments\|reviews\|board` | `subject comments\|reviews\|topics <id>` |
+| `/subject/<id>/characters\|persons\|collections\|index` | `subject characters\|staff\|collects\|indexes <id>` |
+| `/subject/<id>/ep` | `episode list <id>` |
+| `/subject/topic/<id>` | `subject topic <id>` |
+| `/group/topic/<id>` | `group topic <id>` |
+| `/group/topic/<id>#post_<pid>` | `group post <pid>` |
+| `/group/<name>[/forum\|members]` | `group get\|topics\|members <name>` |
+| `/ep/<id>` | `episode get <id>` |
+| `/character/<id>`, `/person/<id>` | `character\|person get <id>` |
+| `/blog/<id>`, `/index/<id>` | `blog\|index get <id>` |
+| `/user/<name>[/timeline\|blog\|index\|friends\|followers\|groups]` | matching user/timeline/blog/index/group command |
+| `/<anime\|book\|music\|game\|real>/list/<name>[/<status>]` | `collection list --user <name> --type <type> [--status ...]` |
+| `/subject_search/<keyword>?cat=n` | `subject search <keyword> [--type ...]` |
+| `api.bgm.tv/v0/...` | matching read command |
+
+Rules:
+
+- Resolution is offline and read-only; a link never triggers a write.
+- `--dry-run` prints the resolved command and stops. Use it when the mapping matters.
+- `--json` output is the target command payload plus a `resolvedFrom` field.
+- `?page=n` becomes `--offset` with `--limit 20` pinned; unknown query keys are ignored.
+- Extra flags on the command line are forwarded to the resolved command.
+- Quote links containing `#`.
+- Unsupported paths error with a `Did you mean: bgm ...` suggestion. `/rakuen/topic/...` links are in this category.
+- Run `bgm url --help` for the full list.
+
 ## User Reads
 
 ```bash

--- a/src/cli.js
+++ b/src/cli.js
@@ -120,6 +120,8 @@ import { runTrendingCommand } from "./commands/trending.js";
 import { runNotifyCommand } from "./commands/notify.js";
 import { runBookCommand } from "./commands/book.js";
 import { runSearchCommand } from "./commands/search.js";
+import { runUrlCommand } from "./commands/url.js";
+import { looksLikeBangumiUrl } from "./utils/bangumi-url.js";
 
 const CLI_DIR = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(CLI_DIR, "..");
@@ -161,12 +163,22 @@ async function main(argv) {
     return;
   }
 
+  if (parsed.url !== undefined) {
+    await runUrlCommand([parsed.url, ...parsed.args], context);
+    return;
+  }
+
   if (parsed.args.length === 0) {
     printUsage();
     return;
   }
 
   const [group, command, ...rest] = parsed.args;
+
+  if (looksLikeBangumiUrl(group)) {
+    await runUrlCommand(parsed.args, context);
+    return;
+  }
 
   switch (group) {
     case "tui":
@@ -233,6 +245,9 @@ async function main(argv) {
       return;
     case "calendar":
       await runCalendarCommand(command, rest, context);
+      return;
+    case "url":
+      await runUrlCommand([command, ...rest], context);
       return;
     default:
       throw new CommandError(`Unknown command group: ${group}`);

--- a/src/commands/url.js
+++ b/src/commands/url.js
@@ -1,0 +1,108 @@
+/**
+ * URL command: turn a pasted Bangumi link into the equivalent bgm CLI command.
+ *
+ * Resolution is read-only. A link never triggers a write operation.
+ */
+
+import { CommandError, printResult } from "../core/output.js";
+import {
+  formatResolvedCommand,
+  looksLikeBangumiUrl,
+  resolveBangumiUrl,
+} from "../utils/bangumi-url.js";
+import { runBlogCommand } from "./blog.js";
+import { runCalendarCommand } from "./calendar.js";
+import { runCharacterCommand } from "./character.js";
+import { runCollectionCommand } from "./collection.js";
+import { runEpisodeCommand } from "./episode.js";
+import { runGroupCommand } from "./group.js";
+import { runIndexCommand } from "./index.js";
+import { runNotifyCommand } from "./notify.js";
+import { runPersonCommand } from "./person.js";
+import { runSubjectCommand } from "./subject.js";
+import { runTimelineCommand } from "./timeline.js";
+import { runUserCommand } from "./user.js";
+
+const COMMAND_RUNNERS = {
+  blog: runBlogCommand,
+  calendar: runCalendarCommand,
+  character: runCharacterCommand,
+  collection: runCollectionCommand,
+  episode: runEpisodeCommand,
+  group: runGroupCommand,
+  index: runIndexCommand,
+  notify: runNotifyCommand,
+  person: runPersonCommand,
+  subject: runSubjectCommand,
+  timeline: runTimelineCommand,
+  user: runUserCommand,
+};
+
+const USAGE = "Usage: bgm [--json] url <bangumi_url> [--dry-run] [extra flags passed to the resolved command]";
+
+export async function runUrlCommand(args, context = {}) {
+  const { url, dryRun, passthrough } = splitUrlArgs(args);
+  if (!url) {
+    throw new CommandError(USAGE);
+  }
+
+  const resolved = resolveBangumiUrl(url);
+  const commandArgs = [...resolved.args, ...passthrough];
+
+  if (dryRun) {
+    printResult(buildDryRunPayload(resolved, commandArgs), context);
+    return;
+  }
+
+  const runner = COMMAND_RUNNERS[resolved.group];
+  if (!runner) {
+    throw new CommandError(`No CLI runner for command group: ${resolved.group}`);
+  }
+
+  await runner(resolved.command, commandArgs, {
+    ...context,
+    resolvedFrom: {
+      url: resolved.url,
+      site: resolved.site,
+      command: `${resolved.group} ${resolved.command}`,
+      args: commandArgs,
+    },
+  });
+}
+
+export function buildDryRunPayload(resolved, commandArgs = resolved.args) {
+  return {
+    resource: "url-resolve",
+    url: resolved.url,
+    site: resolved.site,
+    path: resolved.path,
+    command: `${resolved.group} ${resolved.command}`,
+    args: commandArgs,
+    commandLine: formatResolvedCommand({ ...resolved, args: commandArgs }),
+  };
+}
+
+/**
+ * Split raw args into the URL, the --dry-run switch, and flags forwarded to the
+ * resolved command. Done by hand so `--dry-run <url>` cannot swallow the URL.
+ */
+export function splitUrlArgs(args) {
+  const tokens = args.filter((token) => token !== undefined && token !== null).map(String);
+  const rest = tokens.filter((token) => token !== "--dry-run");
+  const dryRun = tokens.length !== rest.length;
+
+  let urlIndex = rest.findIndex((token) => looksLikeBangumiUrl(token));
+  if (urlIndex === -1) {
+    urlIndex = rest.findIndex((token) => !token.startsWith("-"));
+  }
+
+  if (urlIndex === -1) {
+    return { url: undefined, dryRun, passthrough: rest };
+  }
+
+  return {
+    url: rest[urlIndex],
+    dryRun,
+    passthrough: [...rest.slice(0, urlIndex), ...rest.slice(urlIndex + 1)],
+  };
+}

--- a/src/core/output.js
+++ b/src/core/output.js
@@ -290,6 +290,36 @@ function buildUsageText(target) {
         ["bgm [--json] person edit-comment <comment_id> <content>", "Edit one of your person comments."],
         ["bgm [--json] person delete-comment <comment_id>", "Delete one of your person comments."],
       ]);
+    case "url":
+      return buildGroupUsage("URL", [
+        ["bgm [--json] <bangumi_url> [--dry-run]", "Resolve a pasted Bangumi link and run the matching command."],
+        ["bgm [--json] url <bangumi_url> [--dry-run]", "Same, as an explicit subcommand."],
+        ["bgm [--json] --url <bangumi_url> [--dry-run]", "Same, as a global flag. `-url` is accepted as an alias."],
+      ], [
+        "Supported hosts",
+        "  bgm.tv, bangumi.tv, chii.in, next.bgm.tv, api.bgm.tv (optional www. prefix,",
+        "  optional https:// prefix).",
+        "",
+        "Supported links",
+        "  /subject/<id>[/comments|reviews|board|characters|persons|collections|index|ep]",
+        "  /subject/topic/<id>[#post_<id>]      /group/topic/<id>[#post_<id>]",
+        "  /group/<name>[/forum|members]        /group/category/all",
+        "  /ep/<id>                             /blog/<id>[/photos]",
+        "  /character/<id>[/collections|indices|album]",
+        "  /person/<id>[/collections|indices|album|works|collabs]",
+        "  /index/<id>[/comments]               /user/<name>[/timeline|blog|index|friends|followers|groups]",
+        "  /user/<name>/mono/<character|person> /<anime|book|music|game|real>/list/<name>[/<status>]",
+        "  /<anime|book|music|game|real>/browser|tag/<tag>",
+        "  /subject_search/<keyword>            /mono_search/<keyword>",
+        "  /calendar  /timeline  /notify        /v0/... on api.bgm.tv",
+        "",
+        "Notes",
+        "  Resolution is read-only and offline; a link never triggers a write.",
+        "  A #post_<id> anchor resolves to that single reply, not the whole topic.",
+        "  ?page=n becomes --offset (with --limit 20 pinned); unknown query keys are ignored.",
+        "  Extra flags are forwarded to the resolved command.",
+        "  Quote URLs containing '#' so the shell does not truncate them.",
+      ]);
     case "trending":
       return buildGroupUsage("Trending", [
         ["bgm [--json] trending subjects --type <book|anime|music|game|real> [--limit n] [--offset n]", "List trending subjects."],
@@ -331,6 +361,9 @@ Core
     Show reading progress for a book-type subject.
   bgm [--json] book ep <subject_id> <chapter_number>
     Update chapter progress for a book-type subject.
+  bgm [--json] <bangumi_url> [--dry-run]
+    Resolve a pasted Bangumi link (bgm.tv/bangumi.tv/chii.in/next.bgm.tv/api.bgm.tv)
+    and run the matching command. See: bgm url --help
   bgm [--json] group list [--limit n]
     List Bangumi groups.
   bgm [--json] status
@@ -367,6 +400,9 @@ Examples
   bgm book ep 3510 10
   bgm group list --limit 10
   bgm notify --limit 10
+  bgm "https://bangumi.tv/group/topic/469977#post_4029724"
+  bgm url https://bgm.tv/subject/253/characters
+  bgm --url https://bgm.tv/anime/list/sai/collect --dry-run
   bgm blog --help
   bgm episode --help`;
 }
@@ -401,11 +437,37 @@ function normalizeUsageTarget(target) {
 
 export function printResult(value, context = {}) {
   if (context.json) {
-    console.log(JSON.stringify(value, null, 2));
+    console.log(JSON.stringify(withResolvedFrom(value, context), null, 2));
     return;
   }
 
   console.log(formatDisplayResult(value, context));
+}
+
+/**
+ * Tag a JSON payload with the URL it was resolved from, so `bgm <url> --json`
+ * stays byte-compatible with the underlying command plus one extra key.
+ */
+function withResolvedFrom(value, context) {
+  if (!context.resolvedFrom || value === null || typeof value !== "object" || Array.isArray(value)) {
+    return value;
+  }
+
+  return { ...value, resolvedFrom: context.resolvedFrom };
+}
+
+function isUrlResolvePayload(value) {
+  return value?.resource === "url-resolve" && typeof value.commandLine === "string";
+}
+
+function formatUrlResolve(payload) {
+  return [
+    "URL resolve (dry run)",
+    `  URL: ${payload.url}`,
+    `  Site: ${payload.site}`,
+    `  Path: ${payload.path}`,
+    `  Command: ${payload.commandLine}`,
+  ].join("\n");
 }
 
 export function formatDisplayResult(value, context = {}) {
@@ -415,6 +477,10 @@ export function formatDisplayResult(value, context = {}) {
 
   if (typeof value === "string") {
     return value;
+  }
+
+  if (isUrlResolvePayload(value)) {
+    return formatUrlResolve(value);
   }
 
   if (isConfigShowPayload(value)) {

--- a/src/utils/args.js
+++ b/src/utils/args.js
@@ -10,6 +10,7 @@ export function parseGlobalArgs(argv) {
   let init = false;
   let version = false;
   let profile;
+  let url;
 
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
@@ -34,6 +35,23 @@ export function parseGlobalArgs(argv) {
       index += 1;
       continue;
     }
+    if (arg === "--url" || arg === "-url") {
+      const next = argv[index + 1];
+      if (next === undefined || next.startsWith("-")) {
+        throw new CommandError("Usage: bgm --url <bangumi_url> [--dry-run]");
+      }
+      url = next;
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--url=") || arg.startsWith("-url=")) {
+      const value = arg.slice(arg.indexOf("=") + 1);
+      if (value === "") {
+        throw new CommandError("Usage: bgm --url <bangumi_url> [--dry-run]");
+      }
+      url = value;
+      continue;
+    }
     if (arg.startsWith("--profile=")) {
       const value = arg.slice("--profile=".length);
       if (value === "") {
@@ -45,7 +63,7 @@ export function parseGlobalArgs(argv) {
     args.push(arg);
   }
 
-  return { args, json, init, version, profile };
+  return { args, json, init, version, profile, url };
 }
 
 export function parseFlags(args) {

--- a/src/utils/bangumi-url.js
+++ b/src/utils/bangumi-url.js
@@ -1,0 +1,650 @@
+/**
+ * Bangumi URL parsing and command resolution.
+ *
+ * Turns a pasted bgm.tv / bangumi.tv / chii.in / next.bgm.tv / api.bgm.tv link
+ * into the bgm CLI command that shows the same resource. Resolution is pure and
+ * offline: no request is made while parsing.
+ */
+
+import { CommandError } from "../core/output.js";
+
+export const WEB_HOSTS = new Set(["bgm.tv", "bangumi.tv", "chii.in", "next.bgm.tv"]);
+export const API_HOSTS = new Set(["api.bgm.tv"]);
+
+/** Page size assumed when a URL carries ?page=n and no explicit limit. */
+export const URL_PAGE_SIZE = 20;
+
+const SUBJECT_TYPE_SLUGS = new Set(["book", "anime", "music", "game", "real"]);
+
+const SUBJECT_SEARCH_CATEGORIES = {
+  1: "book",
+  2: "anime",
+  3: "music",
+  4: "game",
+  6: "real",
+};
+
+/** Old-site collection status path segments -> CLI --status values. */
+const COLLECTION_STATUS_SLUGS = {
+  wish: "wish",
+  collect: "collect",
+  do: "doing",
+  on_hold: "on_hold",
+  dropped: "dropped",
+};
+
+const SUBJECT_SUBPAGES = {
+  comments: ["subject", "comments"],
+  reviews: ["subject", "reviews"],
+  board: ["subject", "topics"],
+  characters: ["subject", "characters"],
+  persons: ["subject", "staff"],
+  collections: ["subject", "collects"],
+  index: ["subject", "indexes"],
+  ep: ["episode", "list"],
+};
+
+const CHARACTER_SUBPAGES = {
+  collections: "collects",
+  indices: "indexes",
+  album: "photos",
+};
+
+const PERSON_SUBPAGES = {
+  collections: "collects",
+  indices: "indexes",
+  album: "photos",
+  works: "works",
+  collabs: "relations",
+};
+
+const SUBJECT_LIST_SORTS = new Set(["date", "rank"]);
+const SUBJECT_SEARCH_SORTS = new Set(["match", "heat", "rank", "score"]);
+const COLLECTION_SORTS = new Set(["updated", "name", "rank", "community_score", "user_score", "date"]);
+
+/**
+ * Parse a possible Bangumi URL. Returns null when the value is not a URL on a
+ * supported host, so callers can fall back to normal command parsing.
+ */
+export function parseBangumiUrl(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  if (trimmed === "" || /\s/.test(trimmed)) {
+    return null;
+  }
+
+  const withScheme = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  let parsed;
+  try {
+    parsed = new URL(withScheme);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return null;
+  }
+
+  const host = parsed.hostname.toLowerCase().replace(/^www\./, "");
+  if (!WEB_HOSTS.has(host) && !API_HOSTS.has(host)) {
+    return null;
+  }
+
+  const segments = parsed.pathname
+    .split("/")
+    .filter(Boolean)
+    .map(decodeSegment);
+
+  const query = {};
+  for (const [key, entry] of parsed.searchParams.entries()) {
+    if (query[key] === undefined) {
+      query[key] = entry;
+    }
+  }
+
+  return {
+    url: trimmed,
+    host,
+    kind: API_HOSTS.has(host) ? "api" : "web",
+    path: `/${segments.join("/")}`,
+    segments,
+    query,
+    hash: parsed.hash.replace(/^#/, ""),
+  };
+}
+
+export function looksLikeBangumiUrl(value) {
+  return parseBangumiUrl(value) !== null;
+}
+
+/**
+ * Resolve a Bangumi URL into { group, command, args }.
+ * Throws a CommandError (with a `bgm ...` suggestion when one can be derived)
+ * for supported hosts whose path has no CLI equivalent.
+ */
+export function resolveBangumiUrl(value) {
+  const parsed = parseBangumiUrl(value);
+  if (!parsed) {
+    throw new CommandError(
+      `Not a supported Bangumi URL: ${value}\nSupported hosts: ${[...WEB_HOSTS, ...API_HOSTS].join(", ")}`,
+    );
+  }
+
+  const resolved = parsed.kind === "api" ? resolveApiPath(parsed) : resolveWebPath(parsed);
+  return {
+    ...resolved,
+    url: parsed.url,
+    site: parsed.host,
+  };
+}
+
+export function formatResolvedCommand(resolved) {
+  return ["bgm", resolved.group, resolved.command, ...resolved.args]
+    .filter((entry) => entry !== undefined && entry !== "")
+    .map(quoteArg)
+    .join(" ");
+}
+
+function resolveWebPath(parsed) {
+  const { segments } = parsed;
+  if (segments.length === 0) {
+    throw unsupported(parsed, "The site homepage has no single CLI equivalent.");
+  }
+
+  switch (segments[0]) {
+    case "subject":
+      return resolveSubject(parsed);
+    case "group":
+      return resolveGroup(parsed);
+    case "ep":
+      return command("episode", "get", [requireId(segments[1], "episode id", parsed)], parsed);
+    case "character":
+      return resolveMono(parsed, "character", CHARACTER_SUBPAGES);
+    case "person":
+      return resolveMono(parsed, "person", PERSON_SUBPAGES);
+    case "user":
+      return resolveUser(parsed);
+    case "blog":
+      return resolveBlog(parsed);
+    case "index":
+      return resolveIndex(parsed);
+    case "subject_search":
+      return resolveSubjectSearch(parsed);
+    case "mono_search":
+      return resolveMonoSearch(parsed);
+    case "calendar":
+      return command("calendar", "all", [], parsed);
+    case "timeline":
+      return command("timeline", "list", pagingArgs(parsed, { untilKey: "until" }), parsed);
+    case "notify":
+      return command("notify", "list", pagingArgs(parsed, { limitOnly: true }), parsed);
+    case "rakuen":
+      return resolveRakuen(parsed);
+    default:
+      if (SUBJECT_TYPE_SLUGS.has(segments[0])) {
+        return resolveTypeSection(parsed);
+      }
+      throw unsupported(parsed);
+  }
+}
+
+function resolveSubject(parsed) {
+  const { segments } = parsed;
+
+  if (segments[1] === "topic") {
+    const topicId = requireId(segments[2], "topic id", parsed);
+    const postId = postIdFromHash(parsed.hash);
+    if (postId) {
+      return command("subject", "post", [postId], parsed);
+    }
+    return command("subject", "topic", [topicId], parsed);
+  }
+
+  const subjectId = requireId(segments[1], "subject id", parsed);
+  const sub = segments[2];
+
+  if (sub === undefined) {
+    return command("subject", "get", [subjectId], parsed);
+  }
+
+  const mapped = SUBJECT_SUBPAGES[sub];
+  if (!mapped || segments.length > 3) {
+    throw unsupported(parsed, undefined, `bgm subject get ${subjectId}`);
+  }
+
+  const [group, name] = mapped;
+  const args = [subjectId, ...pagingArgs(parsed)];
+  if (group === "subject" && name === "comments") {
+    const type = collectionStatusFromQuery(parsed.query.type ?? parsed.query.filter);
+    if (type) {
+      args.push("--type", type);
+    }
+  }
+  return command(group, name, args, parsed);
+}
+
+function resolveGroup(parsed) {
+  const { segments } = parsed;
+
+  if (segments[1] === "topic") {
+    const topicId = requireId(segments[2], "topic id", parsed);
+    const postId = postIdFromHash(parsed.hash);
+    if (postId) {
+      return command("group", "post", [postId], parsed);
+    }
+    return command("group", "topic", [topicId], parsed);
+  }
+
+  if (segments[1] === "category") {
+    const args = pagingArgs(parsed);
+    if (segments[2] === "all" || segments[2] === undefined) {
+      args.unshift("--mode", "all");
+    }
+    return command("group", "list", args, parsed);
+  }
+
+  const name = requireSlug(segments[1], "group name", parsed);
+  const sub = segments[2];
+
+  if (sub === undefined) {
+    return command("group", "get", [name], parsed);
+  }
+  if (sub === "forum" && segments.length === 3) {
+    return command("group", "topics", [name, ...pagingArgs(parsed)], parsed);
+  }
+  if (sub === "members" && segments.length === 3) {
+    const args = [name, ...pagingArgs(parsed)];
+    if (typeof parsed.query.role === "string" && parsed.query.role !== "") {
+      args.push("--role", parsed.query.role);
+    }
+    return command("group", "members", args, parsed);
+  }
+
+  throw unsupported(parsed, undefined, `bgm group get ${name}`);
+}
+
+function resolveMono(parsed, kind, subpages) {
+  const { segments } = parsed;
+  const id = requireId(segments[1], `${kind} id`, parsed);
+  const sub = segments[2];
+
+  if (sub === undefined) {
+    return command(kind, "get", [id], parsed);
+  }
+
+  const mapped = subpages[sub];
+  if (!mapped || (segments.length > 3 && sub !== "works")) {
+    throw unsupported(parsed, undefined, `bgm ${kind} get ${id}`);
+  }
+
+  return command(kind, mapped, [id, ...pagingArgs(parsed)], parsed);
+}
+
+function resolveUser(parsed) {
+  const { segments } = parsed;
+  const username = requireSlug(segments[1], "username", parsed);
+  const sub = segments[2];
+
+  if (sub === undefined) {
+    return command("user", "get", [username], parsed);
+  }
+
+  if (segments.length === 3) {
+    switch (sub) {
+      case "timeline":
+        return command("timeline", "user", [username, ...pagingArgs(parsed, { untilKey: "until" })], parsed);
+      case "blog":
+        return command("blog", "list", ["--user", username, ...pagingArgs(parsed)], parsed);
+      case "index":
+        return command("index", "user", [username, ...pagingArgs(parsed)], parsed);
+      case "friends":
+        return command("user", "friends", [username, ...pagingArgs(parsed)], parsed);
+      case "followers":
+        return command("user", "followers", [username, ...pagingArgs(parsed)], parsed);
+      case "groups":
+        return command("group", "user", [username, ...pagingArgs(parsed)], parsed);
+      case "mono":
+        throw unsupported(
+          parsed,
+          "This page mixes character and person collections.",
+          `bgm collection characters --user ${username}\n              bgm collection persons --user ${username}`,
+        );
+      default:
+        break;
+    }
+  }
+
+  if (sub === "mono" && segments.length === 4) {
+    if (segments[3] === "character") {
+      return command("collection", "characters", ["--user", username, ...pagingArgs(parsed)], parsed);
+    }
+    if (segments[3] === "person") {
+      return command("collection", "persons", ["--user", username, ...pagingArgs(parsed)], parsed);
+    }
+  }
+
+  throw unsupported(parsed, undefined, `bgm user get ${username}`);
+}
+
+function resolveBlog(parsed) {
+  const { segments } = parsed;
+  const blogId = requireId(segments[1], "blog id", parsed);
+
+  if (segments.length === 2) {
+    return command("blog", "get", [blogId], parsed);
+  }
+  if (segments[2] === "photos" && segments.length === 3) {
+    return command("blog", "photos", [blogId, ...pagingArgs(parsed)], parsed);
+  }
+
+  throw unsupported(parsed, undefined, `bgm blog get ${blogId}`);
+}
+
+function resolveIndex(parsed) {
+  const { segments } = parsed;
+  const indexId = requireId(segments[1], "index id", parsed);
+
+  if (segments.length === 2) {
+    return command("index", "get", [indexId], parsed);
+  }
+  if (segments[2] === "comments" && segments.length === 3) {
+    return command("index", "comments", [indexId], parsed);
+  }
+
+  throw unsupported(parsed, undefined, `bgm index get ${indexId}`);
+}
+
+function resolveSubjectSearch(parsed) {
+  const keyword = requireKeyword(parsed.segments[1], parsed);
+  const args = [keyword];
+
+  const type = SUBJECT_SEARCH_CATEGORIES[Number(parsed.query.cat)];
+  if (type) {
+    args.push("--type", type);
+  }
+  if (SUBJECT_SEARCH_SORTS.has(parsed.query.sort)) {
+    args.push("--sort", parsed.query.sort);
+  }
+
+  return command("subject", "search", args, parsed);
+}
+
+function resolveMonoSearch(parsed) {
+  const keyword = requireKeyword(parsed.segments[1], parsed);
+  const cat = Number(parsed.query.cat);
+  const group = cat === 2 ? "person" : "character";
+  return command(group, "search", [keyword, ...pagingArgs(parsed)], parsed);
+}
+
+function resolveTypeSection(parsed) {
+  const { segments } = parsed;
+  const type = segments[0];
+  const section = segments[1];
+
+  if (section === "list") {
+    const username = requireSlug(segments[2], "username", parsed);
+    const args = ["--user", username, "--type", type];
+    const status = COLLECTION_STATUS_SLUGS[segments[3] ?? ""];
+    if (segments[3] !== undefined && !status) {
+      throw unsupported(parsed, undefined, `bgm collection list --user ${username} --type ${type}`);
+    }
+    if (status) {
+      args.push("--status", status);
+    }
+    if (typeof parsed.query.tag === "string" && parsed.query.tag !== "") {
+      args.push("--tag", parsed.query.tag);
+    }
+    if (COLLECTION_SORTS.has(parsed.query.orderby)) {
+      args.push("--sort", parsed.query.orderby);
+    }
+    args.push(...pagingArgs(parsed));
+    return command("collection", "list", args, parsed);
+  }
+
+  if (section === "browser" && segments.length === 2) {
+    const args = ["--type", type];
+    if (SUBJECT_LIST_SORTS.has(parsed.query.sort)) {
+      args.push("--sort", parsed.query.sort);
+    }
+    args.push(...pagingArgs(parsed, { limitOnly: true }));
+    return command("subject", "list", args, parsed);
+  }
+
+  if (section === "tag" && segments.length === 3) {
+    const args = ["--type", type, "--tag", segments[2]];
+    if (SUBJECT_LIST_SORTS.has(parsed.query.sort)) {
+      args.push("--sort", parsed.query.sort);
+    }
+    args.push(...pagingArgs(parsed, { limitOnly: true }));
+    return command("subject", "list", args, parsed);
+  }
+
+  throw unsupported(parsed, undefined, `bgm subject list --type ${type}`);
+}
+
+function resolveRakuen(parsed) {
+  const { segments } = parsed;
+  if (segments[1] === "topic" && segments[3] !== undefined) {
+    const id = String(segments[3]);
+    if (/^\d+$/.test(id) && (segments[2] === "group" || segments[2] === "subject")) {
+      throw unsupported(parsed, undefined, `bgm ${segments[2]} topic ${id}`);
+    }
+  }
+  throw unsupported(parsed);
+}
+
+function resolveApiPath(parsed) {
+  const { segments } = parsed;
+
+  if (segments[0] === "calendar") {
+    return command("calendar", "all", [], parsed);
+  }
+  if (segments[0] !== "v0") {
+    throw unsupported(parsed);
+  }
+
+  const resource = segments[1];
+  const id = segments[2];
+  const sub = segments[3];
+
+  switch (resource) {
+    case "me":
+      return command("user", "me", [], parsed);
+    case "subjects": {
+      const subjectId = requireId(id, "subject id", parsed);
+      if (sub === undefined) {
+        return command("subject", "get", [subjectId], parsed);
+      }
+      if (sub === "persons") {
+        return command("subject", "staff", [subjectId, ...pagingArgs(parsed)], parsed);
+      }
+      if (sub === "characters") {
+        return command("subject", "characters", [subjectId, ...pagingArgs(parsed)], parsed);
+      }
+      if (sub === "subjects") {
+        return command("subject", "relations", [subjectId, ...pagingArgs(parsed)], parsed);
+      }
+      throw unsupported(parsed, undefined, `bgm subject get ${subjectId}`);
+    }
+    case "episodes": {
+      if (id === undefined) {
+        const subjectId = requireId(parsed.query.subject_id, "subject id", parsed);
+        const args = [subjectId, ...pagingArgs(parsed)];
+        return command("episode", "list", args, parsed);
+      }
+      return command("episode", "get", [requireId(id, "episode id", parsed)], parsed);
+    }
+    case "characters": {
+      const characterId = requireId(id, "character id", parsed);
+      if (sub === undefined) {
+        return command("character", "get", [characterId], parsed);
+      }
+      if (sub === "subjects" || sub === "persons") {
+        return command("character", "casts", [characterId, ...pagingArgs(parsed)], parsed);
+      }
+      throw unsupported(parsed, undefined, `bgm character get ${characterId}`);
+    }
+    case "persons": {
+      const personId = requireId(id, "person id", parsed);
+      if (sub === undefined) {
+        return command("person", "get", [personId], parsed);
+      }
+      if (sub === "subjects") {
+        return command("person", "works", [personId, ...pagingArgs(parsed)], parsed);
+      }
+      if (sub === "characters") {
+        return command("person", "casts", [personId, ...pagingArgs(parsed)], parsed);
+      }
+      throw unsupported(parsed, undefined, `bgm person get ${personId}`);
+    }
+    case "users": {
+      const username = requireSlug(id, "username", parsed);
+      if (sub === undefined) {
+        return command("user", "get", [username], parsed);
+      }
+      if (sub === "collections") {
+        const args = ["--user", username];
+        const type = SUBJECT_TYPE_SLUGS.has(parsed.query.subject_type)
+          ? parsed.query.subject_type
+          : SUBJECT_SEARCH_CATEGORIES[Number(parsed.query.subject_type)];
+        if (type) {
+          args.push("--type", type);
+        }
+        args.push(...pagingArgs(parsed));
+        return command("collection", "list", args, parsed);
+      }
+      throw unsupported(parsed, undefined, `bgm user get ${username}`);
+    }
+    case "indices": {
+      const indexId = requireId(id, "index id", parsed);
+      if (sub === undefined) {
+        return command("index", "get", [indexId], parsed);
+      }
+      if (sub === "subjects") {
+        return command("index", "related", [indexId, "--cat", "subject", ...pagingArgs(parsed)], parsed);
+      }
+      throw unsupported(parsed, undefined, `bgm index get ${indexId}`);
+    }
+    default:
+      throw unsupported(parsed);
+  }
+}
+
+function command(group, name, args, parsed) {
+  return {
+    group,
+    command: name,
+    args: args.map(String),
+    path: parsed.path,
+  };
+}
+
+/**
+ * Translate ?page= / ?limit= / ?offset= into CLI paging flags.
+ * A page beyond the first also pins --limit so the offset stays meaningful.
+ */
+function pagingArgs(parsed, { limitOnly = false, untilKey } = {}) {
+  const args = [];
+  const explicitLimit = positiveIntOrNull(parsed.query.limit);
+  const page = positiveIntOrNull(parsed.query.page);
+  const offset = nonNegativeIntOrNull(parsed.query.offset);
+  const limit = explicitLimit ?? (page !== null && page > 1 ? URL_PAGE_SIZE : null);
+
+  if (limit !== null) {
+    args.push("--limit", String(limit));
+  }
+
+  if (untilKey && typeof parsed.query[untilKey] === "string" && /^\d+$/.test(parsed.query[untilKey])) {
+    args.push("--until", parsed.query[untilKey]);
+    return args;
+  }
+
+  if (limitOnly) {
+    return args;
+  }
+
+  if (offset !== null) {
+    args.push("--offset", String(offset));
+  } else if (page !== null && page > 1) {
+    args.push("--offset", String((page - 1) * (limit ?? URL_PAGE_SIZE)));
+  }
+
+  return args;
+}
+
+function collectionStatusFromQuery(value) {
+  if (typeof value !== "string" || value === "") {
+    return undefined;
+  }
+  return COLLECTION_STATUS_SLUGS[value.toLowerCase()];
+}
+
+function postIdFromHash(hash) {
+  const match = /^post_(\d+)$/.exec(String(hash ?? ""));
+  return match ? match[1] : undefined;
+}
+
+function decodeSegment(segment) {
+  try {
+    return decodeURIComponent(segment);
+  } catch {
+    return segment;
+  }
+}
+
+function positiveIntOrNull(value) {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return null;
+  }
+  const parsed = Number(value);
+  return parsed > 0 ? parsed : null;
+}
+
+function nonNegativeIntOrNull(value) {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    return null;
+  }
+  return Number(value);
+}
+
+function requireId(value, label, parsed) {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) {
+    throw unsupported(parsed, `Expected a numeric ${label}.`);
+  }
+  return value;
+}
+
+function requireSlug(value, label, parsed) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9_-]+$/.test(value)) {
+    throw unsupported(parsed, `Expected a valid ${label}.`);
+  }
+  return value;
+}
+
+function requireKeyword(value, parsed) {
+  if (typeof value !== "string" || value === "") {
+    throw unsupported(parsed, "Expected a search keyword in the URL path.");
+  }
+  return value;
+}
+
+function unsupported(parsed, reason, suggestion) {
+  const lines = [`Unsupported Bangumi URL path: ${parsed.path || "/"}`];
+  if (reason) {
+    lines.push(reason);
+  }
+  if (suggestion) {
+    lines.push(`Did you mean: ${suggestion}`);
+  } else {
+    lines.push("Run `bgm url --help` to see the supported link shapes.");
+  }
+  return new CommandError(lines.join("\n"));
+}
+
+function quoteArg(value) {
+  const text = String(value);
+  return /[\s"'#]/.test(text) ? JSON.stringify(text) : text;
+}

--- a/test/url-resolve.test.js
+++ b/test/url-resolve.test.js
@@ -1,0 +1,371 @@
+import { spawnSync } from "node:child_process";
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import {
+  formatResolvedCommand,
+  looksLikeBangumiUrl,
+  parseBangumiUrl,
+  resolveBangumiUrl,
+} from "../src/utils/bangumi-url.js";
+import { splitUrlArgs } from "../src/commands/url.js";
+import { parseGlobalArgs } from "../src/utils/args.js";
+
+function line(url) {
+  return formatResolvedCommand(resolveBangumiUrl(url));
+}
+
+function expectError(url) {
+  return assert.throws(() => resolveBangumiUrl(url), { name: "CommandError" });
+}
+
+describe("looksLikeBangumiUrl", () => {
+  const accepted = [
+    "https://bgm.tv/subject/253",
+    "http://bangumi.tv/subject/253",
+    "https://www.bgm.tv/subject/253",
+    "https://chii.in/subject/253",
+    "https://next.bgm.tv/subject/253",
+    "https://api.bgm.tv/v0/subjects/253",
+    "bgm.tv/subject/253",
+  ];
+  for (const url of accepted) {
+    it(`should accept ${url}`, () => {
+      assert.strictEqual(looksLikeBangumiUrl(url), true);
+    });
+  }
+
+  const rejected = [
+    "subject",
+    "collection",
+    "https://example.com/subject/253",
+    "https://notbgm.tv/subject/253",
+    "ftp://bgm.tv/subject/253",
+    "",
+    "https://bgm.tv.evil.com/subject/253",
+  ];
+  for (const value of rejected) {
+    it(`should reject ${value || "(empty)"}`, () => {
+      assert.strictEqual(looksLikeBangumiUrl(value), false);
+    });
+  }
+
+  it("should not shadow any existing command group", () => {
+    const groups = [
+      "tui", "config", "proxy", "auth", "setup", "subject", "character", "person",
+      "episode", "ep", "group", "blog", "timeline", "trending", "index",
+      "collection", "book", "status", "user", "search", "notify", "calendar", "url",
+    ];
+    for (const group of groups) {
+      assert.strictEqual(looksLikeBangumiUrl(group), false, `${group} must not parse as a URL`);
+    }
+  });
+});
+
+describe("parseBangumiUrl", () => {
+  it("should strip the www prefix and lowercase the host", () => {
+    assert.strictEqual(parseBangumiUrl("https://WWW.BGM.TV/subject/253").host, "bgm.tv");
+  });
+
+  it("should tolerate trailing and duplicate slashes", () => {
+    assert.strictEqual(parseBangumiUrl("https://bgm.tv//subject//253/").path, "/subject/253");
+  });
+
+  it("should decode percent-encoded path segments", () => {
+    assert.strictEqual(parseBangumiUrl("https://bgm.tv/subject_search/%E6%B5%B7%E8%B4%BC").segments[1], "海贼");
+  });
+
+  it("should expose the fragment without the hash", () => {
+    assert.strictEqual(parseBangumiUrl("https://bgm.tv/group/topic/1#post_2").hash, "post_2");
+  });
+});
+
+describe("resolveBangumiUrl: subject", () => {
+  const cases = [
+    ["https://bgm.tv/subject/253", "bgm subject get 253"],
+    ["https://bgm.tv/subject/253/comments", "bgm subject comments 253"],
+    ["https://bgm.tv/subject/253/reviews", "bgm subject reviews 253"],
+    ["https://bgm.tv/subject/253/board", "bgm subject topics 253"],
+    ["https://bgm.tv/subject/253/characters", "bgm subject characters 253"],
+    ["https://bgm.tv/subject/253/persons", "bgm subject staff 253"],
+    ["https://bgm.tv/subject/253/collections", "bgm subject collects 253"],
+    ["https://bgm.tv/subject/253/index", "bgm subject indexes 253"],
+    ["https://bgm.tv/subject/253/ep", "bgm episode list 253"],
+    ["https://bgm.tv/subject/topic/1", "bgm subject topic 1"],
+    ["https://bgm.tv/subject/topic/1#post_2", "bgm subject post 2"],
+    ["https://bgm.tv/subject/253/comments?type=do", "bgm subject comments 253 --type doing"],
+  ];
+  for (const [url, expected] of cases) {
+    it(`${url} -> ${expected}`, () => assert.strictEqual(line(url), expected));
+  }
+
+  it("should reject the fake /discussion path with a suggestion", () => {
+    assert.throws(() => resolveBangumiUrl("https://bgm.tv/subject/253/discussion"), (error) => {
+      assert.match(error.message, /Did you mean: bgm subject get 253/);
+      return true;
+    });
+  });
+});
+
+describe("resolveBangumiUrl: group", () => {
+  const cases = [
+    ["https://bangumi.tv/group/topic/469977", "bgm group topic 469977"],
+    ["https://bangumi.tv/group/topic/469977#post_4029724", "bgm group post 4029724"],
+    ["https://bgm.tv/group/boring", "bgm group get boring"],
+    ["https://bgm.tv/group/boring/forum", "bgm group topics boring"],
+    ["https://bgm.tv/group/boring/members", "bgm group members boring"],
+    ["https://bgm.tv/group/boring/members?role=member", "bgm group members boring --role member"],
+    ["https://bgm.tv/group/category/all", "bgm group list --mode all"],
+  ];
+  for (const [url, expected] of cases) {
+    it(`${url} -> ${expected}`, () => assert.strictEqual(line(url), expected));
+  }
+});
+
+describe("resolveBangumiUrl: mono, blog, index, episode", () => {
+  const cases = [
+    ["https://bgm.tv/ep/519", "bgm episode get 519"],
+    ["https://bgm.tv/character/1", "bgm character get 1"],
+    ["https://bgm.tv/character/1/collections", "bgm character collects 1"],
+    ["https://bgm.tv/character/1/indices", "bgm character indexes 1"],
+    ["https://bgm.tv/character/1/album", "bgm character photos 1"],
+    ["https://bgm.tv/person/1", "bgm person get 1"],
+    ["https://bgm.tv/person/1/works", "bgm person works 1"],
+    ["https://bgm.tv/person/1/works/voice", "bgm person works 1"],
+    ["https://bgm.tv/person/1/collabs", "bgm person relations 1"],
+    ["https://bgm.tv/person/1/album", "bgm person photos 1"],
+    ["https://bgm.tv/blog/1", "bgm blog get 1"],
+    ["https://bgm.tv/blog/1/photos", "bgm blog photos 1"],
+    ["https://bgm.tv/index/1", "bgm index get 1"],
+    ["https://bgm.tv/index/1/comments", "bgm index comments 1"],
+  ];
+  for (const [url, expected] of cases) {
+    it(`${url} -> ${expected}`, () => assert.strictEqual(line(url), expected));
+  }
+});
+
+describe("resolveBangumiUrl: user and collections", () => {
+  const cases = [
+    ["https://bgm.tv/user/snape", "bgm user get snape"],
+    ["https://bgm.tv/user/snape/timeline", "bgm timeline user snape"],
+    ["https://bgm.tv/user/snape/blog", "bgm blog list --user snape"],
+    ["https://bgm.tv/user/snape/index", "bgm index user snape"],
+    ["https://bgm.tv/user/snape/friends", "bgm user friends snape"],
+    ["https://bgm.tv/user/snape/followers", "bgm user followers snape"],
+    ["https://bgm.tv/user/snape/groups", "bgm group user snape"],
+    ["https://bgm.tv/user/snape/mono/character", "bgm collection characters --user snape"],
+    ["https://bgm.tv/user/snape/mono/person", "bgm collection persons --user snape"],
+    ["https://bgm.tv/anime/list/snape", "bgm collection list --user snape --type anime"],
+    ["https://bgm.tv/anime/list/snape/wish", "bgm collection list --user snape --type anime --status wish"],
+    ["https://bgm.tv/anime/list/snape/do", "bgm collection list --user snape --type anime --status doing"],
+    ["https://bgm.tv/book/list/snape/collect", "bgm collection list --user snape --type book --status collect"],
+    ["https://bgm.tv/game/list/snape/on_hold", "bgm collection list --user snape --type game --status on_hold"],
+    ["https://bgm.tv/real/list/snape/dropped", "bgm collection list --user snape --type real --status dropped"],
+  ];
+  for (const [url, expected] of cases) {
+    it(`${url} -> ${expected}`, () => assert.strictEqual(line(url), expected));
+  }
+
+  it("should refuse the ambiguous /mono page and suggest both commands", () => {
+    assert.throws(() => resolveBangumiUrl("https://bgm.tv/user/snape/mono"), (error) => {
+      assert.match(error.message, /collection characters --user snape/);
+      assert.match(error.message, /collection persons --user snape/);
+      return true;
+    });
+  });
+});
+
+describe("resolveBangumiUrl: browse and search", () => {
+  const cases = [
+    ["https://bgm.tv/anime/browser", "bgm subject list --type anime"],
+    ["https://bgm.tv/anime/browser?sort=rank", "bgm subject list --type anime --sort rank"],
+    ["https://bgm.tv/anime/browser?sort=nonsense", "bgm subject list --type anime"],
+    ["https://bgm.tv/anime/tag/科幻", "bgm subject list --type anime --tag 科幻"],
+    ["https://bgm.tv/subject_search/EVA", "bgm subject search EVA"],
+    ["https://bgm.tv/subject_search/EVA?cat=2", "bgm subject search EVA --type anime"],
+    ["https://bgm.tv/subject_search/EVA?cat=1&sort=rank", "bgm subject search EVA --type book --sort rank"],
+    ["https://bgm.tv/mono_search/EVA?cat=1", "bgm character search EVA"],
+    ["https://bgm.tv/mono_search/EVA?cat=2", "bgm person search EVA"],
+    ["https://bgm.tv/calendar", "bgm calendar all"],
+    ["https://bgm.tv/timeline", "bgm timeline list"],
+    ["https://bgm.tv/notify", "bgm notify list"],
+  ];
+  for (const [url, expected] of cases) {
+    it(`${url} -> ${expected}`, () => assert.strictEqual(line(url), expected));
+  }
+});
+
+describe("resolveBangumiUrl: api.bgm.tv", () => {
+  const cases = [
+    ["https://api.bgm.tv/v0/subjects/253", "bgm subject get 253"],
+    ["https://api.bgm.tv/v0/subjects/253/characters", "bgm subject characters 253"],
+    ["https://api.bgm.tv/v0/subjects/253/persons", "bgm subject staff 253"],
+    ["https://api.bgm.tv/v0/subjects/253/subjects", "bgm subject relations 253"],
+    ["https://api.bgm.tv/v0/episodes/519", "bgm episode get 519"],
+    ["https://api.bgm.tv/v0/episodes?subject_id=253", "bgm episode list 253"],
+    ["https://api.bgm.tv/v0/characters/1", "bgm character get 1"],
+    ["https://api.bgm.tv/v0/persons/1", "bgm person get 1"],
+    ["https://api.bgm.tv/v0/persons/1/subjects", "bgm person works 1"],
+    ["https://api.bgm.tv/v0/users/snape", "bgm user get snape"],
+    ["https://api.bgm.tv/v0/users/snape/collections", "bgm collection list --user snape"],
+    ["https://api.bgm.tv/v0/indices/1", "bgm index get 1"],
+    ["https://api.bgm.tv/v0/indices/1/subjects", "bgm index related 1 --cat subject"],
+    ["https://api.bgm.tv/v0/me", "bgm user me"],
+    ["https://api.bgm.tv/calendar", "bgm calendar all"],
+  ];
+  for (const [url, expected] of cases) {
+    it(`${url} -> ${expected}`, () => assert.strictEqual(line(url), expected));
+  }
+});
+
+describe("resolveBangumiUrl: cross-host equivalence", () => {
+  for (const host of ["bgm.tv", "bangumi.tv", "chii.in", "next.bgm.tv"]) {
+    it(`${host} resolves like bgm.tv`, () => {
+      assert.strictEqual(line(`https://${host}/group/topic/469977#post_4029724`), "bgm group post 4029724");
+      assert.strictEqual(line(`https://${host}/subject/253`), "bgm subject get 253");
+    });
+  }
+});
+
+describe("resolveBangumiUrl: paging", () => {
+  it("should leave page=1 alone", () => {
+    assert.strictEqual(line("https://bgm.tv/subject/253/comments?page=1"), "bgm subject comments 253");
+  });
+
+  it("should turn page=3 into a pinned limit and offset", () => {
+    assert.strictEqual(
+      line("https://bgm.tv/subject/253/comments?page=3"),
+      "bgm subject comments 253 --limit 20 --offset 40",
+    );
+  });
+
+  it("should honour an explicit limit when computing the offset", () => {
+    assert.strictEqual(
+      line("https://bgm.tv/subject/253/comments?page=3&limit=10"),
+      "bgm subject comments 253 --limit 10 --offset 20",
+    );
+  });
+
+  it("should prefer an explicit offset over page", () => {
+    assert.strictEqual(
+      line("https://bgm.tv/subject/253/comments?page=3&offset=5"),
+      "bgm subject comments 253 --limit 20 --offset 5",
+    );
+  });
+
+  it("should ignore unknown query keys", () => {
+    assert.strictEqual(line("https://bgm.tv/subject/253?utm_source=x&foo=bar"), "bgm subject get 253");
+  });
+});
+
+describe("resolveBangumiUrl: errors", () => {
+  it("should reject an unsupported host", () => expectError("https://example.com/subject/253"));
+  it("should reject a non-numeric subject id", () => expectError("https://bgm.tv/subject/abc"));
+  it("should reject an unknown top-level path", () => expectError("https://bgm.tv/settings"));
+  it("should reject the site homepage", () => expectError("https://bgm.tv/"));
+
+  it("should point rakuen group topic links at the group command", () => {
+    assert.throws(() => resolveBangumiUrl("https://bangumi.tv/rakuen/topic/group/469977"), (error) => {
+      assert.match(error.message, /Did you mean: bgm group topic 469977/);
+      return true;
+    });
+  });
+
+  it("should point rakuen subject topic links at the subject command", () => {
+    assert.throws(() => resolveBangumiUrl("https://bangumi.tv/rakuen/topic/subject/1"), (error) => {
+      assert.match(error.message, /Did you mean: bgm subject topic 1/);
+      return true;
+    });
+  });
+});
+
+describe("splitUrlArgs", () => {
+  it("should read the url from the first positional", () => {
+    const parsed = splitUrlArgs(["https://bgm.tv/subject/253", "--verbose"]);
+    assert.strictEqual(parsed.url, "https://bgm.tv/subject/253");
+    assert.strictEqual(parsed.dryRun, false);
+    assert.deepStrictEqual(parsed.passthrough, ["--verbose"]);
+  });
+
+  it("should not let --dry-run swallow the url", () => {
+    const parsed = splitUrlArgs(["--dry-run", "https://bgm.tv/subject/253"]);
+    assert.strictEqual(parsed.url, "https://bgm.tv/subject/253");
+    assert.strictEqual(parsed.dryRun, true);
+    assert.deepStrictEqual(parsed.passthrough, []);
+  });
+
+  it("should keep flag order for passthrough", () => {
+    const parsed = splitUrlArgs(["https://bgm.tv/subject/253", "--limit", "5", "--offset", "1"]);
+    assert.deepStrictEqual(parsed.passthrough, ["--limit", "5", "--offset", "1"]);
+  });
+});
+
+describe("parseGlobalArgs --url", () => {
+  it("should read --url <value>", () => {
+    assert.strictEqual(parseGlobalArgs(["--url", "https://bgm.tv/subject/253"]).url, "https://bgm.tv/subject/253");
+  });
+
+  it("should read --url=<value>", () => {
+    assert.strictEqual(parseGlobalArgs(["--url=https://bgm.tv/subject/253"]).url, "https://bgm.tv/subject/253");
+  });
+
+  it("should accept the -url alias", () => {
+    assert.strictEqual(parseGlobalArgs(["-url", "https://bgm.tv/subject/253"]).url, "https://bgm.tv/subject/253");
+    assert.strictEqual(parseGlobalArgs(["-url=https://bgm.tv/subject/253"]).url, "https://bgm.tv/subject/253");
+  });
+
+  it("should reject a missing value", () => {
+    assert.throws(() => parseGlobalArgs(["--url"]), { name: "CommandError" });
+    assert.throws(() => parseGlobalArgs(["--url="]), { name: "CommandError" });
+  });
+
+  it("should leave other args untouched", () => {
+    const parsed = parseGlobalArgs(["--json", "--url", "https://bgm.tv/subject/253", "--dry-run"]);
+    assert.strictEqual(parsed.json, true);
+    assert.deepStrictEqual(parsed.args, ["--dry-run"]);
+  });
+});
+
+describe("url command end to end (offline)", () => {
+  function run(args) {
+    return spawnSync("node", ["src/cli.js", ...args], { encoding: "utf-8", cwd: process.cwd() });
+  }
+
+  it("should resolve a bare url via --dry-run", () => {
+    const result = run(["https://bangumi.tv/group/topic/469977#post_4029724", "--dry-run"]);
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /bgm group post 4029724/);
+  });
+
+  it("should resolve the url subcommand", () => {
+    const result = run(["url", "https://bgm.tv/subject/253/characters", "--dry-run"]);
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /bgm subject characters 253/);
+  });
+
+  it("should resolve the --url flag with json output", () => {
+    const result = run(["--json", "--url", "https://bgm.tv/ep/519", "--dry-run"]);
+    assert.strictEqual(result.status, 0);
+    const payload = JSON.parse(result.stdout);
+    assert.strictEqual(payload.resource, "url-resolve");
+    assert.strictEqual(payload.command, "episode get");
+    assert.deepStrictEqual(payload.args, ["519"]);
+  });
+
+  it("should forward extra flags into the resolved command", () => {
+    const result = run(["https://bgm.tv/subject/253/comments", "--limit", "5", "--dry-run", "--json"]);
+    assert.strictEqual(result.status, 0);
+    assert.deepStrictEqual(JSON.parse(result.stdout).args, ["253", "--limit", "5"]);
+  });
+
+  it("should fail with a suggestion on an unsupported path", () => {
+    const result = run(["https://bgm.tv/subject/1234/wiki", "--dry-run"]);
+    assert.notStrictEqual(result.status, 0);
+    assert.match(result.stderr + result.stdout, /Did you mean: bgm subject get 1234/);
+  });
+
+  it("should show url help", () => {
+    const result = run(["url", "--help"]);
+    assert.strictEqual(result.status, 0);
+    assert.match(result.stdout, /Supported hosts/);
+  });
+});


### PR DESCRIPTION
## Summary
- Hand a Bangumi web link (bgm.tv / bangumi.tv / chii.in / next.bgm.tv / api.bgm.tv) straight to `bgm` and it runs the matching command, via three equivalent entry points: bare `bgm <url>`, `bgm url <url>`, and `bgm --url <url>` (`-url` alias).
- Read-only, offline resolution covering subjects and sub-pages, subject/group topics and single posts (`#post_<id>` anchors), groups, episodes, characters, persons, blogs, indexes, user pages, per-type collection lists, browse/tag/search pages, calendar/timeline/notify, and the api.bgm.tv v0 equivalents.
- `--dry-run` prints the resolved command without a request; extra flags forward to the resolved command; `--json` adds a single `resolvedFrom` field so existing parsers keep working.
- Docs updated: three-language README, `docs/features.zh-CN.md`, `skills/bgm-cli-operate`.

## Test plan
- [x] `npm test` (248 tests, all passing, includes 125 new offline URL-resolution tests)
- [x] Manually verified path shapes against the live site (bgm.tv/bangumi.tv/next.bgm.tv/api.bgm.tv), including three corrections vs. the obvious guess (collection status segment `do` not `doing`, `/board` and `/collections` instead of nonexistent `/discussion` and `/related`, `/album` for photos)
- [x] Diffed resolved-URL output against the equivalent hand-typed command; byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SK5Xr5SefMQZppDH1tBaA