### PR TITLE
fix: stop rendering episodes as subjects and objects as platforms

### DIFF
--- a/src/core/output.js
+++ b/src/core/output.js
@@ -685,6 +685,10 @@ export function formatDisplayResult(value, context = {}) {
     return formatPagedSubjects(value);
   }
 
+  if (isEpisodeDetailPayload(value)) {
+    return formatEpisodeDetail(value, context);
+  }
+
   if (isSubjectPayload(value)) {
     return formatSubject(value, context);
   }
@@ -2963,6 +2967,22 @@ function formatCalendar(payload) {
   return lines.join("\n").trim();
 }
 
+/**
+ * The public API returns `platform` as a string, the private API as an object.
+ */
+function formatSubjectPlatform(platform) {
+  if (platform === null || platform === undefined) {
+    return "";
+  }
+  if (typeof platform === "string" || typeof platform === "number") {
+    return String(platform);
+  }
+  if (!isObject(platform)) {
+    return "";
+  }
+  return String(platform.typeCN || platform.type || platform.alias || "");
+}
+
 function formatSubject(subject, context = {}) {
   const verbose = Boolean(context?.verbose);
   const lines = [
@@ -2979,8 +2999,9 @@ function formatSubject(subject, context = {}) {
   if (subject.date) {
     lines.push(`  Date: ${subject.date}`);
   }
-  if (subject.platform) {
-    lines.push(`  Platform: ${subject.platform}`);
+  const platform = formatSubjectPlatform(subject.platform);
+  if (platform) {
+    lines.push(`  Platform: ${platform}`);
   }
   if (subject.eps || subject.total_episodes) {
     lines.push(`  Episodes: ${subject.total_episodes ?? subject.eps ?? "-"}`);
@@ -3064,6 +3085,55 @@ function formatSubject(subject, context = {}) {
     lines.push("");
     lines.push("Meta Tags");
     lines.push(`  ${subject.meta_tags.slice(0, 10).join(", ")}`);
+  }
+
+  return lines.join("\n");
+}
+
+function formatEpisodeDetail(episode, context = {}) {
+  const verbose = Boolean(context?.verbose);
+  const subjectId = episode.subject_id ?? episode.subjectID;
+  const chineseName = episode.name_cn || episode.nameCN;
+  const lines = [
+    `Episode #${episode.id ?? "-"}`,
+    `  Name: ${episode.name || chineseName || "-"}`,
+  ];
+
+  if (chineseName && chineseName !== episode.name) {
+    lines.push(`  Chinese name: ${chineseName}`);
+  }
+
+  lines.push(`  Type: ${formatEpisodeType(episode.type)}`);
+
+  const number = formatEpisodeNumber(episode);
+  if (number) {
+    lines.push(`  Number: ${number}`);
+  }
+  if (subjectId) {
+    const subject = episode.subject;
+    const subjectName = subject?.name_cn || subject?.nameCN || subject?.name;
+    lines.push(`  Subject: #${subjectId}${subjectName ? ` ${subjectName}` : ""}`);
+  }
+  if (episode.airdate) {
+    lines.push(`  Air date: ${episode.airdate}`);
+  }
+  if (episode.duration) {
+    lines.push(`  Duration: ${episode.duration}`);
+  }
+  if (episode.disc) {
+    lines.push(`  Disc: ${episode.disc}`);
+  }
+  if (episode.comment !== undefined) {
+    lines.push(`  Comments: ${episode.comment}`);
+  }
+  if (episode.id) {
+    lines.push(`  URL: https://bgm.tv/ep/${episode.id}`);
+  }
+
+  if (episode.desc) {
+    lines.push("");
+    lines.push("Summary");
+    lines.push(indentBlock(truncateText(String(episode.desc).trim(), verbose ? 800 : 400), 2));
   }
 
   return lines.join("\n");
@@ -3915,6 +3985,18 @@ function isUserPayload(value) {
 
 function isPagedSubjectPayload(value) {
   return isObject(value) && Array.isArray(value.data) && ("total" in value || "limit" in value || "filters" in value);
+}
+
+/**
+ * One episode as returned by `episode get`. It carries id/name/type just like a
+ * subject, so this has to be checked before isSubjectPayload.
+ */
+function isEpisodeDetailPayload(value) {
+  return isObject(value)
+    && value.resource === undefined
+    && "id" in value
+    && ("subject_id" in value || "subjectID" in value)
+    && ("sort" in value || "ep" in value);
 }
 
 function isSubjectPayload(value) {

--- a/test/episode-output.test.js
+++ b/test/episode-output.test.js
@@ -1,0 +1,134 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import { formatDisplayResult } from "../src/core/output.js";
+
+const EPISODE = {
+  id: 519,
+  name: "アステロイド・ブルース Asteroid Blues",
+  name_cn: "小行星蓝调",
+  nameCN: "小行星蓝调",
+  type: 0,
+  ep: 1,
+  sort: 1,
+  airdate: "1998-10-23",
+  duration: "00:24:43",
+  comment: 109,
+  disc: 0,
+  desc: "Episode summary.",
+  subject_id: 253,
+  subjectID: 253,
+  subject: {
+    id: 253,
+    name: "カウボーイビバップ",
+    nameCN: "星际牛仔",
+    type: 2,
+  },
+};
+
+describe("episode detail formatting", () => {
+  it("should not fall through to the subject formatter", () => {
+    const output = formatDisplayResult(EPISODE);
+    assert.match(output, /^Episode #519/);
+    assert.doesNotMatch(output, /Subject #519/);
+  });
+
+  it("should use the episode type table, not the subject one", () => {
+    assert.match(formatDisplayResult(EPISODE), /Type: Main/);
+    assert.match(formatDisplayResult({ ...EPISODE, type: 2 }), /Type: OP/);
+  });
+
+  it("should link to the episode page, not the subject page", () => {
+    const output = formatDisplayResult(EPISODE);
+    assert.match(output, /URL: https:\/\/bgm\.tv\/ep\/519/);
+    assert.doesNotMatch(output, /bgm\.tv\/subject\/519/);
+  });
+
+  it("should keep episode-only fields", () => {
+    const output = formatDisplayResult(EPISODE);
+    assert.match(output, /Number: EP 1/);
+    assert.match(output, /Air date: 1998-10-23/);
+    assert.match(output, /Duration: 00:24:43/);
+    assert.match(output, /Comments: 109/);
+    assert.match(output, /Summary/);
+  });
+
+  it("should name the parent subject", () => {
+    assert.match(formatDisplayResult(EPISODE), /Subject: #253 星际牛仔/);
+  });
+
+  it("should fall back to sort for non-main episodes", () => {
+    const output = formatDisplayResult({ ...EPISODE, type: 1, ep: 0, sort: 27 });
+    assert.match(output, /Number: Sort 27/);
+  });
+
+  it("should tolerate a bare episode payload", () => {
+    const output = formatDisplayResult({ id: 7, name: "Bare", type: 0, sort: 3, subject_id: 9 });
+    assert.match(output, /^Episode #7/);
+    assert.match(output, /Subject: #9$/m);
+  });
+
+  it("should still format a subject as a subject", () => {
+    const output = formatDisplayResult({
+      id: 253,
+      name: "カウボーイビバップ",
+      name_cn: "星际牛仔",
+      type: 2,
+      date: "1998-10-23",
+    });
+    assert.match(output, /^Subject #253/);
+    assert.match(output, /Type: Anime/);
+  });
+
+  it("should leave resource-tagged payloads alone", () => {
+    const output = formatDisplayResult({
+      resource: "episode-list",
+      subjectId: 253,
+      data: [],
+      total: 0,
+    });
+    assert.match(output, /^Episodes: #253/);
+  });
+});
+
+describe("subject platform formatting", () => {
+  it("should render a private API platform object", () => {
+    const output = formatDisplayResult({
+      id: 253,
+      name: "カウボーイビバップ",
+      type: 2,
+      platform: { id: 1, type: "TV", typeCN: "TV", alias: "tv" },
+    });
+    assert.match(output, /Platform: TV/);
+    assert.doesNotMatch(output, /\[object Object\]/);
+  });
+
+  it("should prefer the localized platform label", () => {
+    const output = formatDisplayResult({
+      id: 1,
+      name: "Book",
+      type: 1,
+      platform: { type: "Comic", typeCN: "漫画" },
+    });
+    assert.match(output, /Platform: 漫画/);
+  });
+
+  it("should fall back to alias when no type is present", () => {
+    const output = formatDisplayResult({
+      id: 1,
+      name: "Thing",
+      type: 2,
+      platform: { alias: "tv" },
+    });
+    assert.match(output, /Platform: tv/);
+  });
+
+  it("should keep supporting a plain string platform", () => {
+    const output = formatDisplayResult({ id: 253, name: "Name", type: 2, platform: "TV" });
+    assert.match(output, /Platform: TV/);
+  });
+
+  it("should omit the line for an empty platform object", () => {
+    const output = formatDisplayResult({ id: 253, name: "Name", type: 2, platform: {} });
+    assert.doesNotMatch(output, /Platform:/);
+  });
+});


### PR DESCRIPTION
## Summary
- `bgm episode get <id>` was rendered by the subject formatter (`isSubjectPayload` matches on `id`+`name`+`type`, which an episode payload also has). This mislabelled the header, looked up the episode type in the wrong table, dropped episode-only fields, and printed a link to an unrelated subject that happens to share the id (`bgm.tv/subject/<epid>` instead of `bgm.tv/ep/<epid>`). Added a dedicated episode-detail branch ahead of the subject one.
- `bgm subject get <id>` printed `Platform: [object Object]` because the private API returns `platform` as an object while the formatter assumed a string. Now reads the localized label off the object with a string fallback.
- Both bugs are pre-existing, human-readable-output only (`--json` was already correct), and unrelated to the URL-resolve feature in #6.

## Test plan
- [x] `npm test` (137 tests, all passing, includes 14 new regression tests for both fixes)
- [x] Diffed output of 18 live read commands before/after; only the two intended lines changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SK5Xr5SefMQZppDH1tBaA