### PR TITLE
ci: publish to npm automatically on version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,35 @@ jobs:
       - uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+
+  publish-npm:
+    needs: test
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify tag matches package.json version
+        run: |
+          tag_version="${GITHUB_REF_NAME#v}"
+          pkg_version="$(node -p "require('./package.json').version")"
+          if [ "$tag_version" != "$pkg_version" ]; then
+            echo "Tag v$tag_version does not match package.json version $pkg_version" >&2
+            exit 1
+          fi
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add a `publish-npm` job to `release.yml`, run alongside the existing `release` (GitHub Release) job, both gated on pushing a `v*` tag and on `test` passing.
- Before publishing, verifies the tag's version matches `package.json`'s `version` so a mistagged push can't ship the wrong version.
- Runs `npm publish --provenance --access public` with an `NPM_TOKEN` secret via `NODE_AUTH_TOKEN`; `id-token: write` is scoped to just this job for npm provenance attestation.

## Requires (not part of this PR)
- An `NPM_TOKEN` repository secret — a granular npm automation token scoped to this package (read-write, no orgs). Needs to be created via npmjs.com (requires OTP) and added with `gh secret set NPM_TOKEN` or the GitHub UI. This PR only wires up the job; publishing won't actually run until the secret exists.

## Test plan
- [x] `npm test` unaffected (workflow-only change)
- [ ] After merge: create the `NPM_TOKEN` secret, then push a `v*` tag and confirm the `publish-npm` job succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012SK5Xr5SefMQZppDH1tBaA