### PR TITLE
fix: include private collections for current user, streamline docs, and switch npm release to OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,15 +46,19 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     permissions:
-      contents: read
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v4
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci
@@ -69,6 +73,4 @@ jobs:
           fi
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public

--- a/README.en.md
+++ b/README.en.md
@@ -52,19 +52,6 @@ bgm auth set-token YOUR_ACCESS_TOKEN
 bgm auth token-status
 ```
 
-### Multiple accounts
-
-Snapshot the current credentials as a named profile and switch between accounts quickly:
-
-```bash
-bgm auth profile save main
-bgm auth profile list
-bgm auth profile use another
-bgm --profile another user me
-```
-
-`bgm --profile <name> <command>` runs a single command as that account without switching; it is a read-only override and never writes to disk.
-
 ### Proxy
 
 If your network needs a proxy to reach the Bangumi API reliably, configure an HTTP/HTTPS proxy for all CLI requests:
@@ -102,24 +89,6 @@ bgm search subject "One Piece" --limit 5
 bgm trending subjects --type anime --limit 5
 bgm --json user me
 ```
-
-### Paste A Link
-
-Hand a Bangumi web link straight to `bgm` and it resolves to the matching command:
-
-```bash
-bgm "https://bangumi.tv/group/topic/469977#post_4029724"   # that single reply -> bgm group post 4029724
-bgm url https://bgm.tv/subject/253/characters              # -> bgm subject characters 253
-bgm --url https://bgm.tv/anime/list/sai/collect --dry-run  # resolve only, no request
-```
-
-- Three equivalent forms: `bgm <url>`, `bgm url <url>`, `bgm --url <url>` (`-url` also works).
-- Hosts: `bgm.tv`, `bangumi.tv`, `chii.in`, `next.bgm.tv`, `api.bgm.tv`; the `https://` and `www.` prefixes are optional.
-- Resolution is read-only, so a link never triggers a write. `--dry-run` prints the resolution and stops.
-- A `#post_<id>` anchor resolves to that single reply; `?page=n` becomes `--offset`.
-- Extra flags are forwarded to the resolved command, and `--json` output carries a `resolvedFrom` field.
-- Quote links containing `#` so the shell does not truncate them.
-- Run `bgm url --help` for the full list of supported link shapes.
 
 ## Documentation Index
 

--- a/README.md
+++ b/README.md
@@ -52,19 +52,6 @@ bgm auth set-token YOUR_ACCESS_TOKEN
 bgm auth token-status
 ```
 
-### 多账户
-
-可以把当前凭据存成命名 profile，在多个账户之间快捷切换：
-
-```bash
-bgm auth profile save main
-bgm auth profile list
-bgm auth profile use another
-bgm --profile another user me
-```
-
-`bgm --profile <name> <command>` 只在单条命令内临时使用该账户，不切换、不写盘。
-
 ### 代理
 
 如果你所在网络访问 Bangumi API 不稳定，可以为所有 CLI 请求设置 HTTP/HTTPS 代理：
@@ -109,24 +96,6 @@ bgm trending subjects --type anime --limit 5
 bgm status --site bgm.tv
 bgm --json user me
 ```
-
-### 粘贴链接直接查询
-
-把 Bangumi 网页链接直接交给 `bgm`，它会解析成对应命令并输出同样的结果：
-
-```bash
-bgm "https://bangumi.tv/group/topic/469977#post_4029724"   # 定位到该楼 -> bgm group post 4029724
-bgm url https://bgm.tv/subject/253/characters              # -> bgm subject characters 253
-bgm --url https://bgm.tv/anime/list/sai/collect --dry-run  # 只看解析结果，不发请求
-```
-
-- 三种写法等价：`bgm <url>`、`bgm url <url>`、`bgm --url <url>`（`-url` 亦可）。
-- 支持 `bgm.tv`、`bangumi.tv`、`chii.in`、`next.bgm.tv`、`api.bgm.tv`，可省略 `https://` 与 `www.`。
-- 解析是只读的，链接永远不会触发写操作；`--dry-run` 只打印解析结果。
-- `#post_<id>` 锚点会精确定位到该楼回复；`?page=n` 会换算成 `--offset`。
-- 多余的参数会透传给解析出的命令，`--json` 输出会附带 `resolvedFrom` 溯源字段。
-- 链接含 `#` 时请加引号，否则会被 shell 截断。
-- 完整支持列表见 `bgm url --help`。
 
 ## 文档索引
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -52,19 +52,6 @@ bgm auth set-token YOUR_ACCESS_TOKEN
 bgm auth token-status
 ```
 
-### 多帳戶
-
-可以把當前憑據存成命名 profile，在多個帳戶之間快捷切換：
-
-```bash
-bgm auth profile save main
-bgm auth profile list
-bgm auth profile use another
-bgm --profile another user me
-```
-
-`bgm --profile <name> <command>` 只在單條命令內臨時使用該帳戶，不切換、不寫盤。
-
 ### 代理
 
 如果你所在網路存取 Bangumi API 不穩定，可以為所有 CLI 請求設定 HTTP/HTTPS 代理：
@@ -102,24 +89,6 @@ bgm search subject "海賊王" --limit 5
 bgm trending subjects --type anime --limit 5
 bgm --json user me
 ```
-
-### 貼上連結直接查詢
-
-把 Bangumi 網頁連結直接交給 `bgm`，它會解析成對應命令並輸出同樣的結果：
-
-```bash
-bgm "https://bangumi.tv/group/topic/469977#post_4029724"   # 定位到該樓 -> bgm group post 4029724
-bgm url https://bgm.tv/subject/253/characters              # -> bgm subject characters 253
-bgm --url https://bgm.tv/anime/list/sai/collect --dry-run  # 只看解析結果，不發請求
-```
-
-- 三種寫法等價：`bgm <url>`、`bgm url <url>`、`bgm --url <url>`（`-url` 亦可）。
-- 支援 `bgm.tv`、`bangumi.tv`、`chii.in`、`next.bgm.tv`、`api.bgm.tv`，可省略 `https://` 與 `www.`。
-- 解析是唯讀的，連結永遠不會觸發寫入操作；`--dry-run` 只印出解析結果。
-- `#post_<id>` 錨點會精確定位到該樓回覆；`?page=n` 會換算成 `--offset`。
-- 多餘的參數會透傳給解析出的命令，`--json` 輸出會附帶 `resolvedFrom` 溯源欄位。
-- 連結含 `#` 時請加引號，否則會被 shell 截斷。
-- 完整支援列表見 `bgm url --help`。
 
 ## 文件索引
 

--- a/src/core/client.js
+++ b/src/core/client.js
@@ -1172,7 +1172,23 @@ export class BangumiClient {
       throw new CommandError("Missing username. Pass a username or log in first.");
     }
 
-    const result = await this.request(`/p1/users/${encodeURIComponent(String(username))}/collections/subjects`, {
+    let isMe = false;
+    try {
+      const me = await this.getMe();
+      const meUsername = typeof me?.username === "string" ? me.username.trim() : "";
+      if (meUsername && meUsername.toLowerCase() === String(username).trim().toLowerCase()) {
+        isMe = true;
+      }
+    } catch {
+      isMe = false;
+    }
+
+    const path = isMe
+      ? "/p1/collections/subjects"
+      : `/p1/users/${encodeURIComponent(String(username))}/collections/subjects`;
+
+    const result = await this.request(path, {
+      auth: true,
       query: normalizeSubjectCollectionQuery(query),
     });
     return normalizeSubjectCollectionPage(result);

--- a/test/collections-routing.test.js
+++ b/test/collections-routing.test.js
@@ -1,0 +1,88 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { BangumiClient } from "../src/core/client.js";
+
+describe("BangumiClient listCollections routing", () => {
+  it("should route to /p1/collections/subjects when username is current user", async () => {
+    const requestedUrls = [];
+    globalThis.fetch = async (url) => {
+      requestedUrls.push(url.pathname);
+      if (url.pathname === "/p1/me") {
+        return jsonResponse({ username: "aronnax" });
+      }
+      if (url.pathname === "/p1/collections/subjects") {
+        return jsonResponse({
+          data: [
+            {
+              id: 49131,
+              type: 2,
+              name: "デート・ア・ライブ",
+              nameCN: "约会大作战",
+              interest: {
+                id: 123,
+                type: 2,
+                private: true,
+                rate: 0,
+                updatedAt: 1788657630,
+              },
+            },
+          ],
+          total: 1,
+        });
+      }
+      throw new Error(`Unexpected request: ${url.pathname}`);
+    };
+
+    const client = new BangumiClient();
+    const result = await client.listCollections("aronnax", { subjectType: 2 });
+    assert.ok(requestedUrls.includes("/p1/collections/subjects"));
+    assert.equal(result.data.length, 1);
+    assert.equal(result.data[0].subject_id, 49131);
+    assert.equal(result.data[0].private, true);
+  });
+
+  it("should route to /p1/users/:username/collections/subjects when querying another user", async () => {
+    const requestedUrls = [];
+    globalThis.fetch = async (url) => {
+      requestedUrls.push(url.pathname);
+      if (url.pathname === "/p1/me") {
+        return jsonResponse({ username: "aronnax" });
+      }
+      if (url.pathname === "/p1/users/ceynri/collections/subjects") {
+        return jsonResponse({
+          data: [
+            {
+              id: 5649,
+              type: 2,
+              name: "生徒会役員共",
+              nameCN: "妄想学生会",
+              interest: {
+                id: 456,
+                type: 3,
+                rate: 0,
+                updatedAt: 1788508508,
+              },
+            },
+          ],
+          total: 1,
+        });
+      }
+      throw new Error(`Unexpected request: ${url.pathname}`);
+    };
+
+    const client = new BangumiClient();
+    const result = await client.listCollections("ceynri", { subjectType: 2 });
+    assert.ok(requestedUrls.includes("/p1/users/ceynri/collections/subjects"));
+    assert.equal(result.data.length, 1);
+    assert.equal(result.data[0].subject_id, 5649);
+  });
+});
+
+function jsonResponse(payload, options = {}) {
+  return new Response(JSON.stringify(payload), {
+    status: options.status ?? 200,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}

--- a/test/episode-command.test.js
+++ b/test/episode-command.test.js
@@ -227,7 +227,10 @@ describe("book command", () => {
       if (url.pathname === "/p1/me") {
         return jsonResponse({ username: "testuser" });
       }
-      if (url.pathname === "/p1/users/testuser/collections/subjects") {
+      if (
+        url.pathname === "/p1/users/testuser/collections/subjects" ||
+        url.pathname === "/p1/collections/subjects"
+      ) {
         return jsonResponse({ data: [], total: 0, limit: 100, offset: 0 });
       }
       throw new Error(`Unexpected request: ${url.toString()}`);


### PR DESCRIPTION
## Summary

This PR includes three core improvements:

1. **Fix collection list missing private items (Fixes #9)**:
   - Switches collection list query to use `/p1/collections/subjects` (`getMySubjectCollections`) when target user is the authenticated current user, avoiding the hardcoded public-only filter on `/p1/users/:username/...`.
   - Maintains existing behavior for viewing other users and unauthenticated contexts.
   - Adds unit test `test/collections-routing.test.js`.

2. **Streamline README documentation**:
   - Removes verbose multi-account and URL resolver sections across the 3 multilingual READMEs (`README.md`, `README.en.md`, `README.zh-TW.md`), consolidating detailed command references into `docs/features.zh-CN.md`.

3. **Switch npm publishing to Trusted Publishing (OIDC)**:
   - Updates `.github/workflows/release.yml` to remove legacy static `NPM_TOKEN` authentication.
   - Configures `id-token: write` and updates npm to latest before publishing, enabling automated zero-token OIDC provenance publishing.